### PR TITLE
FIX: Avoid issues when no Icon is set.

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -42,6 +42,10 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._show_icon = True
         self._show_status_tooltip = True
         self._icon_size = -1
+
+        if not hasattr(self, 'icon'):
+            self.icon = None
+
         self.interlock = QFrame(self)
         self.interlock.setObjectName("interlock")
         self.interlock.setSizePolicy(QSizePolicy.Expanding,
@@ -325,12 +329,16 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self.controls_frame.setVisible(controls_visible)
 
         for widget in widgets:
+            if widget is None:
+                continue
             # Each widget is in a separate layout to help with expansion rules
             box_layout = QHBoxLayout()
             box_layout.addWidget(widget)
             layout.addLayout(box_layout)
 
     def setup_icon(self):
+        if not self.icon:
+            return
         self.icon.setMinimumSize(16, 16)
         self.icon.setSizePolicy(QSizePolicy.Expanding,
                                 QSizePolicy.Expanding)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Came across this issue when I tried to demonstrate the widgets to someone.
It happens because at the QtDesigner we add the BaseWidget for the enums to work properly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required so we avoid issues when someone does not define an icon to be used with a symbol.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Nowhere.

<!--
## Screenshots (if appropriate):
-->
