### PR TITLE
FIX: QtDesigner started to present issues with properties returning None

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -209,6 +209,9 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             If the value is <= 0 it will expand to fill the space available.
 
         """
+        if not self.icon:
+            return
+
         if size <= 0:
             size = - 1
             min_size = 1

--- a/pcdswidgets/vacuum/others.py
+++ b/pcdswidgets/vacuum/others.py
@@ -53,12 +53,12 @@ class RGA(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        pass
+        return super(RGA, self).channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        pass
+        return super(RGA, self).showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        pass
+        return super(RGA, self).controlsLocation

--- a/pcdswidgets/vacuum/others.py
+++ b/pcdswidgets/vacuum/others.py
@@ -53,12 +53,12 @@ class RGA(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        return super(RGA, self).channelsPrefix
+        return super().channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        return super(RGA, self).showIcon
+        return super().showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        return super(RGA, self).controlsLocation
+        return super().controlsLocation

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -315,12 +315,12 @@ class GetterPump(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        return super(GetterPump, self).channelsPrefix
+        return super().channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        return super(GetterPump, self).showIcon
+        return super().showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        return super(GetterPump, self).controlsLocation
+        return super().controlsLocation

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -315,12 +315,12 @@ class GetterPump(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        pass
+        return super(GetterPump, self).channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        pass
+        return super(GetterPump, self).showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        pass
+        return super(GetterPump, self).controlsLocation

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -490,12 +490,12 @@ class RightAngleManualValve(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        return super(RightAngleManualValve, self).channelsPrefix
+        return super().channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        return super(RightAngleManualValve, self).showIcon
+        return super().showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        return super(RightAngleManualValve, self).controlsLocation
+        return super().controlsLocation

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -490,12 +490,12 @@ class RightAngleManualValve(PCDSSymbolBase):
 
     @Property(str, designable=False)
     def channelsPrefix(self):
-        pass
+        return super(RightAngleManualValve, self).channelsPrefix
 
     @Property(bool, designable=False)
     def showIcon(self):
-        pass
+        return super(RightAngleManualValve, self).showIcon
 
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
-        pass
+        return super(RightAngleManualValve, self).controlsLocation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Today after updating my code and using Qt newer than 5.6 I started having problems to load the widgets. I narrowed it down to the fact that properties for the widgets were returning None.
I believe that Qt no longer likes it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally since we can't test QtDesigner at CI.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->