### PR TITLE
FIX: Avoid flickering icon windows by creating icons with parents = self.

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -141,7 +141,6 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             self.iconSize = self.iconSize
             self.assemble_layout()
 
-
     @Property(bool)
     def showIcon(self):
         """

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -42,9 +42,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._show_icon = True
         self._show_status_tooltip = True
         self._icon_size = -1
-
-        if not hasattr(self, 'icon'):
-            self.icon = None
+        self._icon = None
 
         self.interlock = QFrame(self)
         self.interlock.setObjectName("interlock")
@@ -130,6 +128,19 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             self._channels_prefix = prefix
             self.destroy_channels()
             self.create_channels()
+
+    @property
+    def icon(self):
+        return self._icon
+
+    @icon.setter
+    def icon(self, icon):
+        if self._icon != icon:
+            self._icon = icon
+            self.setup_icon()
+            self.iconSize = self.iconSize
+            self.assemble_layout()
+
 
     @Property(bool)
     def showIcon(self):

--- a/pcdswidgets/vacuum/gauges.py
+++ b/pcdswidgets/vacuum/gauges.py
@@ -66,13 +66,13 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
     NAME = "Rough Gauge"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = RoughGaugeSymbolIcon()
         super(RoughGauge, self).__init__(
             parent=parent,
             state_suffix=self._state_suffix,
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
+        self.icon = RoughGaugeSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(70, 60)
@@ -145,7 +145,6 @@ class HotCathodeGauge(ButtonLabelControl, InterlockMixin, StateMixin,
     NAME = "Hot Cathode Gauge"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = HotCathodeGaugeSymbolIcon()
         super(HotCathodeGauge, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -154,6 +153,7 @@ class HotCathodeGauge(ButtonLabelControl, InterlockMixin, StateMixin,
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
+        self.icon = HotCathodeGaugeSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 80)
@@ -227,7 +227,6 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
     NAME = "Cold Cathode Gauge"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ColdCathodeGaugeSymbolIcon()
         super(ColdCathodeGauge, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -236,6 +235,7 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
+        self.icon = ColdCathodeGaugeSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 80)

--- a/pcdswidgets/vacuum/others.py
+++ b/pcdswidgets/vacuum/others.py
@@ -37,9 +37,9 @@ class RGA(PCDSSymbolBase):
     NAME = "Residual Gas Analyzer"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = RGASymbolIcon()
         self._controls_location = ContentLocation.Hidden
         super(RGA, self).__init__(parent=parent, **kwargs)
+        self.icon = RGASymbolIcon(parent=self)
 
     def sizeHint(self):
         """

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -82,7 +82,6 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
     NAME = "Ion Pump"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = IonPumpSymbolIcon()
         super(IonPump, self).__init__(parent=parent,
                                       interlock_suffix=self._interlock_suffix,
                                       error_suffix=self._error_suffix,
@@ -91,6 +90,7 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
                                       readback_suffix=self._readback_suffix,
                                       readback_name='pressure',
                                       **kwargs)
+        self.icon = IonPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 80)
@@ -168,7 +168,6 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     NAME = "Turbo Pump"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = TurboPumpSymbolIcon()
         super(TurboPump, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -176,6 +175,7 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = TurboPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 80)
@@ -253,7 +253,6 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     NAME = "Scroll Pump"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ScrollPumpSymbolIcon()
         super(ScrollPump, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -261,6 +260,7 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ScrollPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 80)
@@ -299,9 +299,9 @@ class GetterPump(PCDSSymbolBase):
     NAME = "Getter Pump"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = GetterPumpSymbolIcon()
         self._controls_location = ContentLocation.Hidden
         super(GetterPump, self).__init__(parent=parent, **kwargs)
+        self.icon = GetterPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
         """

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -92,7 +92,6 @@ class PneumaticValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
     NAME = "Pneumatic Valve"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = PneumaticValveSymbolIcon()
         super(PneumaticValve, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -101,6 +100,7 @@ class PneumaticValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
             close_suffix=self._close_state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = PneumaticValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -187,7 +187,6 @@ class ApertureValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
     NAME = "Aperture Valve"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ApertureValveSymbolIcon()
         super(ApertureValve, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -196,6 +195,7 @@ class ApertureValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
             close_suffix=self._close_state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ApertureValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -275,7 +275,6 @@ class FastShutter(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
     NAME = "Fast Shutter"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = FastShutterSymbolIcon()
         super(FastShutter, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -284,6 +283,7 @@ class FastShutter(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
             close_suffix=self._close_state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = FastShutterSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -353,13 +353,13 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
     NAME = "Needle Valve"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = NeedleValveSymbolIcon()
         super(NeedleValve, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = NeedleValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -430,13 +430,13 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
     NAME = "Proportional Valve"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ProportionalValveSymbolIcon()
         super(ProportionalValve, self).__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ProportionalValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -476,9 +476,9 @@ class RightAngleManualValve(PCDSSymbolBase):
     NAME = "Right Angle Manual Valve"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = RightAngleManualValveSymbolIcon()
         self._controls_location = ContentLocation.Hidden
         super(RightAngleManualValve, self).__init__(parent=parent, **kwargs)
+        self.icon = RightAngleManualValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         """
@@ -583,7 +583,6 @@ class ControlValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
     _command_suffix = ":OPN_SW"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ControlValveSymbolIcon()
         super().__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
@@ -592,6 +591,7 @@ class ControlValve(InterlockMixin, ErrorMixin, OpenCloseStateMixin,
             close_suffix=self._close_state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ControlValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -672,13 +672,13 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ControlOnlyValveSymbolIcon()
         super().__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ControlOnlyValveSymbolIcon(parent=self)
 
     def sizeHint(self):
         return QSize(180, 70)
@@ -759,10 +759,10 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
     _command_suffix = ":CLS_SW"
 
     def __init__(self, parent=None, **kwargs):
-        self.icon = ControlOnlyValveSymbolIcon()
         super().__init__(
             parent=parent,
             interlock_suffix=self._interlock_suffix,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.icon = ControlOnlyValveSymbolIcon(parent=self)

--- a/tests/vacuum/test_base.py
+++ b/tests/vacuum/test_base.py
@@ -8,8 +8,8 @@ from pcdswidgets.icons import RGASymbolIcon
 class BaseSymbol(PCDSSymbolBase):
     """Test Symbol for base class tests"""
     def __init__(self, parent=None):
-        self.icon = RGASymbolIcon()
         super().__init__(parent=parent)
+        self.icon = RGASymbolIcon(parent=self)
 
 
 @pytest.fixture(scope='function')

--- a/tests/vacuum/test_mixins.py
+++ b/tests/vacuum/test_mixins.py
@@ -9,8 +9,8 @@ from pcdswidgets.vacuum.mixins import (InterlockMixin, ErrorMixin, StateMixin,
 class PCDSSymbolWithIcon(PCDSSymbolBase):
     """Base mixable class"""
     def __init__(self, *args, **kwargs):
-        self.icon = QWidget()
         super().__init__(*args, **kwargs)
+        self.icon = QWidget(parent=self)
 
 
 class Interlock(InterlockMixin, PCDSSymbolWithIcon):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Icons were being created before the widgets resulting in windows without parent that were floating around. This caused a massive flickering effect when opening the designer via XForwarding.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the issue above which is annoying.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
