### PR TITLE
ENH: Added icon click handler to open TyphosDeviceDisplay as an expert screen.

### DIFF
--- a/pcdswidgets/utils.py
+++ b/pcdswidgets/utils.py
@@ -1,4 +1,10 @@
+import sys
+import inspect
+import importlib
+import logging
 from qtpy.QtWidgets import QWidget
+
+logger = logging.getLogger(__name__)
 
 
 def refresh_style(widget):
@@ -27,3 +33,67 @@ def find_ancestor_for_widget(widget, klass):
         if isinstance(w, klass):
             return w
     return None
+
+
+def _import_helper(klass):
+    """
+    Interpret a device class import string and extract the class object.
+
+    Parameters
+    ----------
+    klass : str
+        The module path to find the class e.g.
+        ``"pcdsdevices.device_types.IPM"``
+
+    Returns
+    -------
+    cls : type
+        The class referred to by the input string.
+    """
+    mod, cls = klass.rsplit('.', 1)
+    # Import the module if not already present
+    # Otherwise use the stashed version in sys.modules
+    if mod in sys.modules:
+        logger.debug("Using previously imported version of %s", mod)
+        mod = sys.modules[mod]
+    else:
+        logger.debug("Importing %s", mod)
+        mod = importlib.import_module(mod)
+    # Gather our device class from the given module
+    try:
+        return getattr(mod, cls)
+    except AttributeError as exc:
+        raise ImportError("Unable to import %s from %s" %
+                          (cls, mod.__name__)) from exc
+
+
+def get_typhos_display(*, klass, name="", prefix):
+    try:
+        import typhos
+    except ImportError:
+        logger.exception('Typhos is unavailable. '
+                         'Please install it to use this feature')
+        return None
+
+    if inspect.isclass(klass):
+        k = klass
+    else:
+        k = _import_helper(klass)
+
+    if not k:
+        logger.error(f'Failed to import class {klass}')
+        return None
+
+    try:
+        obj = k(name=name, prefix=prefix)
+    except Exception:
+        logger.exception('Failed to instantiate object for class %s '
+                         'using prefix %s', klass, prefix)
+
+    try:
+        display = typhos.TyphosDeviceDisplay.from_device(obj)
+        return display
+    except Exception:
+        logger.exception('Failed to generate TyphosDeviceDisplay from '
+                         'device %s', obj)
+        return None

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -362,7 +362,8 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
                                 QSizePolicy.Expanding)
         self.icon.setVisible(self._show_icon)
         self.iconSize = 32
-        self.icon.clicked.connect(self._handle_icon_click)
+        if hasattr(self.icon, 'clicked'):
+            self.icon.clicked.connect(self._handle_icon_click)
 
     def _handle_icon_click(self):
         if not self.channelsPrefix:
@@ -373,7 +374,8 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         klass = getattr(self, "OPHYD_CLASS", None)
         if not klass:
             logger.error('No OPHYD_CLASS specified for pcdswidgets %s',
-                         {self.__class__.__name__})
+                         self.__class__.__name__)
+            return
         name = prefix.replace(':', '_')
         display = get_typhos_display(klass=klass, prefix=prefix, name=name)
         if display:

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -1,12 +1,16 @@
 import os
+import logging
 from pydm.widgets.base import PyDMPrimitiveWidget
 from pydm.widgets.channel import PyDMChannel
+from pydm.utilities import remove_protocol
 from qtpy.QtCore import Property, Q_ENUMS, QSize
 from qtpy.QtGui import QPainter
 from qtpy.QtWidgets import (QWidget, QFrame, QVBoxLayout, QHBoxLayout,
                             QSizePolicy, QStyle, QStyleOption)
 
-from ..utils import refresh_style
+from ..utils import refresh_style, get_typhos_display
+
+logger = logging.getLogger(__name__)
 
 
 class ContentLocation:
@@ -358,6 +362,22 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
                                 QSizePolicy.Expanding)
         self.icon.setVisible(self._show_icon)
         self.iconSize = 32
+        self.icon.clicked.connect(self._handle_icon_click)
+
+    def _handle_icon_click(self):
+        if not self.channelsPrefix:
+            logger.error('No channel prefix specified.'
+                         'Cannot proceed with opening expert screen.')
+            return
+        prefix = remove_protocol(self.channelsPrefix)
+        klass = getattr(self, "OPHYD_CLASS", None)
+        if not klass:
+            logger.error('No OPHYD_CLASS specified for pcdswidgets %s',
+                         {self.__class__.__name__})
+        name = prefix.replace(':', '_')
+        display = get_typhos_display(klass=klass, prefix=prefix, name=name)
+        if display:
+            display.show()
 
     def status_tooltip(self):
         """

--- a/pcdswidgets/vacuum/gauges.py
+++ b/pcdswidgets/vacuum/gauges.py
@@ -66,6 +66,7 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Rough Gauge"
+    OPHYD_CLASS = "pcdsdevices.gauge.GaugePLC"
 
     def __init__(self, parent=None, **kwargs):
         super(RoughGauge, self).__init__(
@@ -229,6 +230,7 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
     _command_suffix = ":HV_SW"
 
     NAME = "Cold Cathode Gauge"
+    OPHYD_CLASS = "pcdsdevices.gauge.GCCPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ColdCathodeGauge, self).__init__(

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -82,6 +82,7 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Ion Pump"
+    OPHYD_CLASS = "pcdsdevices.pump.PIPPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(IonPump, self).__init__(parent=parent,
@@ -169,6 +170,7 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Turbo Pump"
+    OPHYD_CLASS = "pcdsdevices.pump.PTMPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(TurboPump, self).__init__(
@@ -254,6 +256,7 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Scroll Pump"
+    OPHYD_CLASS = "pcdsdevices.pump.PROPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ScrollPump, self).__init__(

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -88,6 +88,7 @@ class PneumaticValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Pneumatic Valve"
+    OPHYD_CLASS = "pcdsdevices.valve.VGC"
 
     def __init__(self, parent=None, **kwargs):
         super(PneumaticValve, self).__init__(
@@ -181,6 +182,7 @@ class ApertureValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Aperture Valve"
+    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ApertureValve, self).__init__(
@@ -267,6 +269,7 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Fast Shutter"
+    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(FastShutter, self).__init__(
@@ -344,6 +347,7 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
     _command_suffix = ":OPN_SW"
 
     NAME = "Needle Valve"
+    OPHYD_CLASS = "pcdsdevices.valve.VCN"
 
     def __init__(self, parent=None, **kwargs):
         super(NeedleValve, self).__init__(
@@ -421,6 +425,7 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
     _command_suffix = ":OPN_SW"
 
     NAME = "Proportional Valve"
+    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ProportionalValve, self).__init__(
@@ -569,6 +574,8 @@ class ControlValve(InterlockMixin, ErrorMixin, StateMixin,
 
     """
     NAME = 'Control Valve with Readback'
+    OPHYD_CLASS = "pcdsdevices.valve.VVC"
+
     _interlock_suffix = ":OPN_OK_RBV"
     _error_suffix = ":STATE_RBV"
     _state_suffix = ":POS_STATE_RBV"
@@ -658,6 +665,8 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Closed Control Valve with No Readback'
+    OPHYD_CLASS = "pcdsdevices.valve.VVC"
+
     _interlock_suffix = ":OPN_OK_RBV"
     _state_suffix = ':OPN_DO_RBV'
     _command_suffix = ":OPN_SW"
@@ -745,6 +754,8 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Open Control Valve with No Readback'
+    OPHYD_CLASS = "pcdsdevices.valve.VVCNO"
+
     _interlock_suffix = ":CLS_OK_RBV"
     _state_suffix = ':CLS_DO_RBV'
     _command_suffix = ":CLS_SW"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added `OPHYD_CLASS` class attribute to widget classes.
This new attribute can be a string or a class that will be used alongside with the `channelPrefix` to create a `TyphosDeviceDisplay` as an expert screen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Request from users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

Attn. @slacAdpai @slacAWallace @sfsyunusSLAC 