### PR TITLE
FIX: Fix the layout setup for widgets.

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -295,7 +295,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         if not self.interlock:
             return
         layout = self.interlock.layout()
-        if not layout:
+        if layout is None:
             return
         while layout.count() != 0:
             item = layout.itemAt(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The if statement was returning True even if layout was a valid object and causing a layout to be set at the `interlock` frame all the time without first removing the old layout.


## Motivation and Context
Fix to remove the annoying message:
```
QWidget::setLayout: Attempting to set QLayout "" on QFrame "interlock", which already has a layout
QWidget::setLayout: Attempting to set QLayout "" on QFrame "interlock", which already has a layout
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
