### PR TITLE
ENH: Add new property ophydClass at BaseWidget

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -50,6 +50,8 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._icon_size = -1
         self._icon = None
 
+        self._ophyd_class = ""
+
         self.interlock = QFrame(self)
         self.interlock.setObjectName("interlock")
         self.interlock.setSizePolicy(QSizePolicy.Expanding,
@@ -270,6 +272,34 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         if self.icon:
             self.icon.rotation = angle
 
+    @Property(str)
+    def ophydClass(self):
+        """
+        The full qualified name of the Ophyd class to be used for the Expert
+        screen to be generated using Typhos.
+
+        Returns
+        -------
+        str
+        """
+        klass = self._ophyd_class
+        if isinstance(klass, type):
+            return f"{klass.__module__}.{klass.__name__}"
+        return klass
+
+    @ophydClass.setter
+    def ophydClass(self, klass):
+        """
+        The full qualified name of the Ophyd class to be used for the Expert
+        screen to be generated using Typhos.
+
+        Parameters
+        ----------
+        klass : bool
+        """
+        if self.ophydClass != klass:
+            self._ophyd_class = klass
+
     def paintEvent(self, evt):
         """
         Paint events are sent to widgets that need to update themselves,
@@ -380,9 +410,9 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             return
 
         prefix = remove_protocol(self.channelsPrefix)
-        klass = getattr(self, "OPHYD_CLASS", None)
+        klass = self._ophyd_class
         if not klass:
-            logger.error('No OPHYD_CLASS specified for pcdswidgets %s',
+            logger.error('No ophydClass specified for pcdswidgets %s',
                          self.__class__.__name__)
             return
         name = prefix.replace(':', '_')

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -34,6 +34,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
     parent : QWidget
         The parent widget for this symbol.
     """
+    EXPERT_OPHYD_CLASS = ""
 
     Q_ENUMS(ContentLocation)
     ContentLocation = ContentLocation
@@ -50,7 +51,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._icon_size = -1
         self._icon = None
 
-        self._ophyd_class = ""
+        self._expert_ophyd_class = self.EXPERT_OPHYD_CLASS or ""
 
         self.interlock = QFrame(self)
         self.interlock.setObjectName("interlock")
@@ -273,7 +274,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             self.icon.rotation = angle
 
     @Property(str)
-    def ophydClass(self):
+    def expertOphydClass(self):
         """
         The full qualified name of the Ophyd class to be used for the Expert
         screen to be generated using Typhos.
@@ -282,13 +283,13 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         -------
         str
         """
-        klass = self._ophyd_class
+        klass = self._expert_ophyd_class
         if isinstance(klass, type):
             return f"{klass.__module__}.{klass.__name__}"
         return klass
 
-    @ophydClass.setter
-    def ophydClass(self, klass):
+    @expertOphydClass.setter
+    def expertOphydClass(self, klass):
         """
         The full qualified name of the Ophyd class to be used for the Expert
         screen to be generated using Typhos.
@@ -298,7 +299,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         klass : bool
         """
         if self.ophydClass != klass:
-            self._ophyd_class = klass
+            self._expert_ophyd_class = klass
 
     def paintEvent(self, evt):
         """
@@ -410,7 +411,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
             return
 
         prefix = remove_protocol(self.channelsPrefix)
-        klass = self._ophyd_class
+        klass = self.expertOphydClass
         if not klass:
             logger.error('No ophydClass specified for pcdswidgets %s',
                          self.__class__.__name__)

--- a/pcdswidgets/vacuum/gauges.py
+++ b/pcdswidgets/vacuum/gauges.py
@@ -66,6 +66,7 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Rough Gauge"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.gauge.GaugePLC"
 
     def __init__(self, parent=None, **kwargs):
         super(RoughGauge, self).__init__(
@@ -74,7 +75,6 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
-        self.ophydClass = "pcdsdevices.gauge.GaugePLC"
         self.icon = RoughGaugeSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 
@@ -230,6 +230,7 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
     _command_suffix = ":HV_SW"
 
     NAME = "Cold Cathode Gauge"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.gauge.GCCPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ColdCathodeGauge, self).__init__(
@@ -240,7 +241,6 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
-        self.ophydClass = "pcdsdevices.gauge.GCCPLC"
         self.icon = ColdCathodeGaugeSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 

--- a/pcdswidgets/vacuum/gauges.py
+++ b/pcdswidgets/vacuum/gauges.py
@@ -66,7 +66,6 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Rough Gauge"
-    OPHYD_CLASS = "pcdsdevices.gauge.GaugePLC"
 
     def __init__(self, parent=None, **kwargs):
         super(RoughGauge, self).__init__(
@@ -75,6 +74,7 @@ class RoughGauge(StateMixin, LabelControl, PCDSSymbolBase):
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
+        self.ophydClass = "pcdsdevices.gauge.GaugePLC"
         self.icon = RoughGaugeSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 
@@ -230,7 +230,6 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
     _command_suffix = ":HV_SW"
 
     NAME = "Cold Cathode Gauge"
-    OPHYD_CLASS = "pcdsdevices.gauge.GCCPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ColdCathodeGauge, self).__init__(
@@ -241,6 +240,7 @@ class ColdCathodeGauge(InterlockMixin, StateMixin, ButtonLabelControl,
             readback_suffix=self._readback_suffix,
             readback_name='pressure',
             **kwargs)
+        self.ophydClass = "pcdsdevices.gauge.GCCPLC"
         self.icon = ColdCathodeGaugeSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -82,7 +82,6 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Ion Pump"
-    OPHYD_CLASS = "pcdsdevices.pump.PIPPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(IonPump, self).__init__(parent=parent,
@@ -93,6 +92,7 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
                                       readback_suffix=self._readback_suffix,
                                       readback_name='pressure',
                                       **kwargs)
+        self.ophydClass = "pcdsdevices.pump.PIPPLC"
         self.icon = IonPumpSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 
@@ -170,7 +170,6 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Turbo Pump"
-    OPHYD_CLASS = "pcdsdevices.pump.PTMPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(TurboPump, self).__init__(
@@ -180,6 +179,7 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.pump.PTMPLC"
         self.icon = TurboPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -256,7 +256,6 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Scroll Pump"
-    OPHYD_CLASS = "pcdsdevices.pump.PROPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ScrollPump, self).__init__(
@@ -266,6 +265,8 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+
+        self.ophydClass = "pcdsdevices.pump.PROPLC"
         self.icon = ScrollPumpSymbolIcon(parent=self)
 
     def sizeHint(self):

--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -82,6 +82,7 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
     _readback_suffix = ":PRESS_RBV"
 
     NAME = "Ion Pump"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.pump.PIPPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(IonPump, self).__init__(parent=parent,
@@ -92,7 +93,6 @@ class IonPump(InterlockMixin, ErrorMixin, StateMixin, ButtonLabelControl,
                                       readback_suffix=self._readback_suffix,
                                       readback_name='pressure',
                                       **kwargs)
-        self.ophydClass = "pcdsdevices.pump.PIPPLC"
         self.icon = IonPumpSymbolIcon(parent=self)
         self.readback_label.displayFormat = DisplayFormat.Exponential
 
@@ -170,6 +170,7 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Turbo Pump"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.pump.PTMPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(TurboPump, self).__init__(
@@ -179,7 +180,6 @@ class TurboPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.pump.PTMPLC"
         self.icon = TurboPumpSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -256,6 +256,7 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
     _command_suffix = ":RUN_SW"
 
     NAME = "Scroll Pump"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.pump.PROPLC"
 
     def __init__(self, parent=None, **kwargs):
         super(ScrollPump, self).__init__(
@@ -265,8 +266,6 @@ class ScrollPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-
-        self.ophydClass = "pcdsdevices.pump.PROPLC"
         self.icon = ScrollPumpSymbolIcon(parent=self)
 
     def sizeHint(self):

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -88,7 +88,6 @@ class PneumaticValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Pneumatic Valve"
-    OPHYD_CLASS = "pcdsdevices.valve.VGC"
 
     def __init__(self, parent=None, **kwargs):
         super(PneumaticValve, self).__init__(
@@ -98,6 +97,7 @@ class PneumaticValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VGC"
         self.icon = PneumaticValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -182,7 +182,6 @@ class ApertureValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Aperture Valve"
-    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ApertureValve, self).__init__(
@@ -192,6 +191,8 @@ class ApertureValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+
+        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = ApertureValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -269,7 +270,6 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Fast Shutter"
-    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(FastShutter, self).__init__(
@@ -279,6 +279,7 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = FastShutterSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -347,7 +348,6 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
     _command_suffix = ":OPN_SW"
 
     NAME = "Needle Valve"
-    OPHYD_CLASS = "pcdsdevices.valve.VCN"
 
     def __init__(self, parent=None, **kwargs):
         super(NeedleValve, self).__init__(
@@ -356,6 +356,7 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VCN"
         self.icon = NeedleValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -425,7 +426,6 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
     _command_suffix = ":OPN_SW"
 
     NAME = "Proportional Valve"
-    OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ProportionalValve, self).__init__(
@@ -434,6 +434,7 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = ProportionalValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -574,7 +575,6 @@ class ControlValve(InterlockMixin, ErrorMixin, StateMixin,
 
     """
     NAME = 'Control Valve with Readback'
-    OPHYD_CLASS = "pcdsdevices.valve.VVC"
 
     _interlock_suffix = ":OPN_OK_RBV"
     _error_suffix = ":STATE_RBV"
@@ -589,6 +589,7 @@ class ControlValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VVC"
         self.icon = ControlValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -665,7 +666,6 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Closed Control Valve with No Readback'
-    OPHYD_CLASS = "pcdsdevices.valve.VVC"
 
     _interlock_suffix = ":OPN_OK_RBV"
     _state_suffix = ':OPN_DO_RBV'
@@ -678,6 +678,7 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VVC"
         self.icon = ControlOnlyValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -754,7 +755,6 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Open Control Valve with No Readback'
-    OPHYD_CLASS = "pcdsdevices.valve.VVCNO"
 
     _interlock_suffix = ":CLS_OK_RBV"
     _state_suffix = ':CLS_DO_RBV'
@@ -767,4 +767,5 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
+        self.ophydClass = "pcdsdevices.valve.VVCNO"
         self.icon = ControlOnlyValveSymbolIcon(parent=self)

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -88,6 +88,7 @@ class PneumaticValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Pneumatic Valve"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VGC"
 
     def __init__(self, parent=None, **kwargs):
         super(PneumaticValve, self).__init__(
@@ -97,7 +98,6 @@ class PneumaticValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VGC"
         self.icon = PneumaticValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -182,6 +182,7 @@ class ApertureValve(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Aperture Valve"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ApertureValve, self).__init__(
@@ -191,8 +192,6 @@ class ApertureValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-
-        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = ApertureValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -270,6 +269,7 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
     _command_suffix = ":OPN_SW"
 
     NAME = "Fast Shutter"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(FastShutter, self).__init__(
@@ -279,7 +279,6 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = FastShutterSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -348,6 +347,7 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
     _command_suffix = ":OPN_SW"
 
     NAME = "Needle Valve"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VCN"
 
     def __init__(self, parent=None, **kwargs):
         super(NeedleValve, self).__init__(
@@ -356,7 +356,6 @@ class NeedleValve(InterlockMixin, StateMixin, ButtonControl, PCDSSymbolBase):
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VCN"
         self.icon = NeedleValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -426,6 +425,7 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
     _command_suffix = ":OPN_SW"
 
     NAME = "Proportional Valve"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VRC"
 
     def __init__(self, parent=None, **kwargs):
         super(ProportionalValve, self).__init__(
@@ -434,7 +434,6 @@ class ProportionalValve(InterlockMixin, StateMixin, ButtonControl,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VRC"
         self.icon = ProportionalValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -575,6 +574,7 @@ class ControlValve(InterlockMixin, ErrorMixin, StateMixin,
 
     """
     NAME = 'Control Valve with Readback'
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VVC"
 
     _interlock_suffix = ":OPN_OK_RBV"
     _error_suffix = ":STATE_RBV"
@@ -589,7 +589,6 @@ class ControlValve(InterlockMixin, ErrorMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VVC"
         self.icon = ControlValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -666,6 +665,7 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Closed Control Valve with No Readback'
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VVC"
 
     _interlock_suffix = ":OPN_OK_RBV"
     _state_suffix = ':OPN_DO_RBV'
@@ -678,7 +678,6 @@ class ControlOnlyValveNC(InterlockMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VVC"
         self.icon = ControlOnlyValveSymbolIcon(parent=self)
 
     def sizeHint(self):
@@ -755,6 +754,7 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
 
     """
     NAME = 'Normally Open Control Valve with No Readback'
+    EXPERT_OPHYD_CLASS = "pcdsdevices.valve.VVCNO"
 
     _interlock_suffix = ":CLS_OK_RBV"
     _state_suffix = ':CLS_DO_RBV'
@@ -767,5 +767,4 @@ class ControlOnlyValveNO(InterlockMixin, StateMixin,
             state_suffix=self._state_suffix,
             command_suffix=self._command_suffix,
             **kwargs)
-        self.ophydClass = "pcdsdevices.valve.VVCNO"
         self.icon = ControlOnlyValveSymbolIcon(parent=self)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR adds a new property called `ophydClass` at `PCDSSymbolBase` that will allow users to opt-out of the default suggested Ophyd Device class to be used for the expert screen.

## Motivation and Context
This is a change requested by @n-wbrown .

## How Has This Been Tested?
Tests are passing.

## Screenshots (if appropriate):
<img width="420" alt="Screen Shot 2020-03-17 at 4 26 27 PM" src="https://user-images.githubusercontent.com/8185425/76911290-ba078380-686d-11ea-865f-b152a3b5d5f8.png">
