### PR TITLE
ENH: Make EnumButtons not checkable.

### DIFF
--- a/pcdswidgets/vacuum/mixins.py
+++ b/pcdswidgets/vacuum/mixins.py
@@ -542,6 +542,7 @@ class ButtonControl(object):
         self._command_suffix = command_suffix
         self._orientation = Qt.Horizontal
         self.control_btn = PyDMEnumButton()
+        self.control_btn.checkable = False
         self.controlButtonHorizontal = True
         self.controls_layout = QVBoxLayout()
         self.controls_layout.setSpacing(2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Makes the EnumButtons non-checkable. This way the buttons will not present the state and cause confusion.

## Motivation and Context
Request from @slacAWallace and @ghalym 

## How Has This Been Tested?
Locally

## Dependencies
This PR depends on the following PyDM PR: https://github.com/slaclab/pydm/pull/614