### PR TITLE
ENH: FastShutter Arrow color

### DIFF
--- a/pcdswidgets/icons/valves.py
+++ b/pcdswidgets/icons/valves.py
@@ -1,8 +1,7 @@
 import math
 
 from qtpy.QtCore import (QPointF, QRectF, Qt, Property, QLineF)
-from qtpy.QtGui import (QPainterPath, QBrush, QColor, QPolygonF, QTransform,
-                        QPen)
+from qtpy.QtGui import (QPainterPath, QBrush, QColor, QPolygonF, QTransform)
 
 from .base import BaseSymbolIcon
 

--- a/pcdswidgets/icons/valves.py
+++ b/pcdswidgets/icons/valves.py
@@ -1,7 +1,8 @@
 import math
 
 from qtpy.QtCore import (QPointF, QRectF, Qt, Property, QLineF)
-from qtpy.QtGui import (QPainterPath, QBrush, QColor, QPolygonF, QTransform)
+from qtpy.QtGui import (QPainterPath, QBrush, QColor, QPolygonF, QTransform,
+                        QPen)
 
 from .base import BaseSymbolIcon
 
@@ -50,6 +51,19 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
     parent : QWidget
         The parent widget for the icon
     """
+    def __init__(self, parent=None, **kwargs):
+        super(FastShutterSymbolIcon, self).__init__(parent, **kwargs)
+        self._arrow_brush = QBrush(QColor("transparent"), Qt.SolidPattern)
+
+    @Property(QBrush)
+    def arrowBrush(self):
+        return self._arrow_brush
+
+    @arrowBrush.setter
+    def arrowBrush(self, new_brush):
+        if new_brush != self._arrow_brush:
+            self._arrow_brush = new_brush
+            self.update()
 
     def draw_icon(self, painter):
         path = QPainterPath(QPointF(0, 0.3))
@@ -59,6 +73,23 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
         path.closeSubpath()
         painter.drawPath(path)
 
+        prev_brush = painter.brush()
+        prev_pen = painter.pen()
+
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(self._arrow_brush)
+        arrow = QPolygonF(
+            [QPointF(0.4, 0),
+             QPointF(0.4, 0.10),
+             QPointF(0.5, 0.25),
+             QPointF(0.6, 0.10),
+             QPointF(0.6, 0)
+             ]
+        )
+        painter.drawPolygon(arrow)
+
+        painter.setPen(prev_pen)
+        painter.setBrush(prev_brush)
         painter.drawLine(QPointF(0.4, 0), QPointF(0.5, 0.15))
         painter.drawLine(QPointF(0.4, 0.10), QPointF(0.5, 0.25))
         painter.drawLine(QPointF(0.5, 0.15), QPointF(0.6, 0))

--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -256,6 +256,7 @@ class FastShutter(InterlockMixin, ErrorMixin, StateMixin,
             qproperty-penStyle: "Qt::DotLine";
             qproperty-penWidth: 2;
             qproperty-brush: red;
+            qproperty-arrowBrush: #00FF00;
         }
         FastShutter [state="Open"] #icon {
             qproperty-penColor: green;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds a new property into the FastShutter icon widget called `arrowBrush` which allow users to customize the brush to paint the arrow area or inverted Christmas three (🤷‍♂️ ).
Attn. @slacAdpai 

## Motivation and Context
Closes #46 

## How Has This Been Tested?
Locally.

## Where Has This Been Documented?
Docs update to include new property.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/8185425/85809932-544d5200-b70e-11ea-83a6-24b197d504e2.png)
