### PR TITLE
ENH: Make arrow bigger for FastShutter valve icon.

### DIFF
--- a/pcdswidgets/icons/base.py
+++ b/pcdswidgets/icons/base.py
@@ -5,7 +5,6 @@ from qtpy.QtWidgets import (QWidget, QStyle, QStyleOption, QToolTip,
 
 from pydm.utilities import (remove_protocol, is_qt_designer)
 from ..utils import find_ancestor_for_widget
-from ..vacuum.base import PCDSSymbolBase
 
 
 class BaseSymbolIcon(QWidget):
@@ -61,6 +60,8 @@ class BaseSymbolIcon(QWidget):
         EDM. If the parent is not PCDSSymbolBase and does not have a valid
         State Channel nothing will be displayed.
         """
+        from ..vacuum.base import PCDSSymbolBase
+
         p = find_ancestor_for_widget(self, PCDSSymbolBase)
         if not p:
             return

--- a/pcdswidgets/icons/valves.py
+++ b/pcdswidgets/icons/valves.py
@@ -79,9 +79,9 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
         painter.setBrush(self._arrow_brush)
         arrow = QPolygonF(
             [QPointF(0.2, 0),
-             QPointF(0.2, 0.10),
-             QPointF(0.5, 0.30),
-             QPointF(0.8, 0.10),
+             QPointF(0.2, 0.20),
+             QPointF(0.5, 0.40),
+             QPointF(0.8, 0.20),
              QPointF(0.8, 0)
              ]
         )
@@ -90,9 +90,9 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
         painter.setPen(prev_pen)
         painter.setBrush(prev_brush)
         painter.drawLine(QPointF(0.2, 0), QPointF(0.5, 0.20))
-        painter.drawLine(QPointF(0.2, 0.10), QPointF(0.5, 0.30))
+        painter.drawLine(QPointF(0.2, 0.20), QPointF(0.5, 0.40))
         painter.drawLine(QPointF(0.5, 0.20), QPointF(0.8, 0))
-        painter.drawLine(QPointF(0.5, 0.30), QPointF(0.8, 0.10))
+        painter.drawLine(QPointF(0.5, 0.40), QPointF(0.8, 0.20))
 
         painter.drawLine(QPointF(0.5, 0.6), QPointF(0.5, 0.0))
 

--- a/pcdswidgets/icons/valves.py
+++ b/pcdswidgets/icons/valves.py
@@ -52,7 +52,7 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
     """
     def __init__(self, parent=None, **kwargs):
         super(FastShutterSymbolIcon, self).__init__(parent, **kwargs)
-        self._arrow_brush = QBrush(QColor("transparent"), Qt.SolidPattern)
+        self._arrow_brush = QBrush(QColor("green"), Qt.SolidPattern)
 
     @Property(QBrush)
     def arrowBrush(self):
@@ -78,21 +78,21 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
         painter.setPen(Qt.NoPen)
         painter.setBrush(self._arrow_brush)
         arrow = QPolygonF(
-            [QPointF(0.4, 0),
-             QPointF(0.4, 0.10),
-             QPointF(0.5, 0.25),
-             QPointF(0.6, 0.10),
-             QPointF(0.6, 0)
+            [QPointF(0.2, 0),
+             QPointF(0.2, 0.10),
+             QPointF(0.5, 0.30),
+             QPointF(0.8, 0.10),
+             QPointF(0.8, 0)
              ]
         )
         painter.drawPolygon(arrow)
 
         painter.setPen(prev_pen)
         painter.setBrush(prev_brush)
-        painter.drawLine(QPointF(0.4, 0), QPointF(0.5, 0.15))
-        painter.drawLine(QPointF(0.4, 0.10), QPointF(0.5, 0.25))
-        painter.drawLine(QPointF(0.5, 0.15), QPointF(0.6, 0))
-        painter.drawLine(QPointF(0.5, 0.25), QPointF(0.6, 0.10))
+        painter.drawLine(QPointF(0.2, 0), QPointF(0.5, 0.20))
+        painter.drawLine(QPointF(0.2, 0.10), QPointF(0.5, 0.30))
+        painter.drawLine(QPointF(0.5, 0.20), QPointF(0.8, 0))
+        painter.drawLine(QPointF(0.5, 0.30), QPointF(0.8, 0.10))
 
         painter.drawLine(QPointF(0.5, 0.6), QPointF(0.5, 0.0))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Increases the arrow at the FastShutter Icon as requested by @slacAdpai 

## Motivation and Context
Closes #52 

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
Before:
![image (1)](https://user-images.githubusercontent.com/8185425/87558632-310f2600-c66e-11ea-8df5-463e86b25a91.png)

After:
![image (3)](https://user-images.githubusercontent.com/8185425/87559041-a4b13300-c66e-11ea-9e91-95aaff16f4ed.png)
