### PR TITLE
FIX: Leftover debug color and fix docs

### DIFF
--- a/pcdswidgets/icons/valves.py
+++ b/pcdswidgets/icons/valves.py
@@ -52,7 +52,7 @@ class FastShutterSymbolIcon(BaseSymbolIcon):
     """
     def __init__(self, parent=None, **kwargs):
         super(FastShutterSymbolIcon, self).__init__(parent, **kwargs)
-        self._arrow_brush = QBrush(QColor("green"), Qt.SolidPattern)
+        self._arrow_brush = QBrush(QColor("transparent"), Qt.SolidPattern)
 
     @Property(QBrush)
     def arrowBrush(self):

--- a/pcdswidgets/vacuum/mixins.py
+++ b/pcdswidgets/vacuum/mixins.py
@@ -697,6 +697,7 @@ class MultipleButtonControl(object):
     commands : list
         List of dictionaries containing the specifications for the buttons.
         Required keys for now are:
+
         - suffix: str
             suffix to be used along with the channelPrefix from PCDSSymbolBase
             to compose the command button channel address


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
FIX: Revert debug green color at FastShutter arrow_brush leftover from test.
DOC: Fix identation at MultipleButton mixin.
