### PR TITLE
ENH: Add custom cursor similar to RelatedDisplayButton for icon with expert screen.

### DIFF
--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -2,9 +2,9 @@ import os
 import logging
 from pydm.widgets.base import PyDMPrimitiveWidget
 from pydm.widgets.channel import PyDMChannel
-from pydm.utilities import remove_protocol
+from pydm.utilities import remove_protocol, IconFont
 from qtpy.QtCore import Property, Q_ENUMS, QSize
-from qtpy.QtGui import QPainter
+from qtpy.QtGui import QPainter, QCursor
 from qtpy.QtWidgets import (QWidget, QFrame, QVBoxLayout, QHBoxLayout,
                             QSizePolicy, QStyle, QStyleOption)
 
@@ -50,6 +50,10 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._show_status_tooltip = True
         self._icon_size = -1
         self._icon = None
+
+        self._icon_cursor = self.setCursor(
+            QCursor(IconFont().icon("file").pixmap(16, 16))
+        )
 
         self._expert_ophyd_class = self.EXPERT_OPHYD_CLASS or ""
 
@@ -396,6 +400,8 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self.iconSize = 32
         if hasattr(self.icon, 'clicked'):
             self.icon.clicked.connect(self._handle_icon_click)
+            if self._expert_display is not None:
+                self.icon.setCursor(self._icon_cursor)
 
     def _handle_icon_click(self):
         if not self.channelsPrefix:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
When a Vacuum widget has an expert screen associated with it, the Cursor now changes in the same way as the PyDM Related Display button.

## Motivation and Context
Requested by Silke. Closes #57 

## How Has This Been Tested?
Locally.

## Where Has This Been Documented?
N/A

## Screenshots (if appropriate):
![normal](https://user-images.githubusercontent.com/8185425/92287027-693c2380-eebd-11ea-952a-53555042b587.jpg)

With mouse over and having an expert screen:
![mouse_over](https://user-images.githubusercontent.com/8185425/92287040-70633180-eebd-11ea-999a-a82432af99f5.jpg)
