### PR TITLE
MNT: remove codecov after recent security breach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
  [![Build Status](https://travis-ci.org/pcdshub/pcdswidgets.svg?branch=master)](https://travis-ci.org/pcdshub/pcdswidgets)
- [![codecov.io](https://codecov.io/github/pcdshub/pcdswidgets/coverage.svg?branch=master)](https://codecov.io/github/pcdshub/pcdswidgets?branch=master)
 # pcdswidgets
 LCLS PyDM Widget Library

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-codecov
 doctr
 flake8
 pytest


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach