### PR TITLE
ENH: add sortable/filterable table inspired by pmps-ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
     # This makes the PIP based Python 3.6 optional for passing.
     # Remove this block if passing tests with PIP is mandatory for your
     # package
-    - name: "Python 3.6 - PIP"
+    - name: "Python - PIP"
 
 import:
   # If your project requires X11 leave the following import

--- a/examples/basic_table.json
+++ b/examples/basic_table.json
@@ -1,0 +1,12 @@
+[
+    {"row_name": "one", "row_value": "1"},
+    {"row_name": "two", "row_value": "2"},
+    {"row_name": "three", "row_value": "3"},
+    {"row_name": "four", "row_value": "4"},
+    {"row_name": "five", "row_value": "5"},
+    {"row_name": "six", "row_value": "6"},
+    {"row_name": "seven", "row_value": "7"},
+    {"row_name": "eight", "row_value": "8"},
+    {"row_name": "nine", "row_value": "9"},
+    {"row_name": "ten", "row_value": "10"}
+]

--- a/examples/basic_table.py
+++ b/examples/basic_table.py
@@ -1,0 +1,7 @@
+import os.path
+
+from pydm import Display
+
+class BasicTable(Display):
+    def ui_filename(self):
+        return os.path.join(os.path.dirname(__file__), 'basic_table.ui')

--- a/examples/basic_table.py
+++ b/examples/basic_table.py
@@ -3,5 +3,35 @@ import os.path
 from pydm import Display
 
 class BasicTable(Display):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ui.example_table.add_filter(
+            'Hide Negative Values',
+            self.neg_filter,
+            active=True,
+        )
+        self.ui.example_table.add_filter(
+            'Hide Even Values',
+            self.even_filter,
+            active=False,
+        )
+        self.ui.example_table.add_filter(
+            'Hide Rows with 4 Character Names',
+            self.four_filter,
+            active=False,
+        )
+
+    def neg_filter(self, value_dict):
+        rbv = value_dict['readback']
+        return rbv is None or rbv >= 0
+
+    def even_filter(self, value_dict):
+        rbv = value_dict['readback']
+        return rbv is None or int(rbv) % 2
+
+    def four_filter(self, value_dict):
+        row_name = value_dict['row_name']
+        return row_name is None or len(row_name) != 4
+
     def ui_filename(self):
         return os.path.join(os.path.dirname(__file__), 'basic_table.ui')

--- a/examples/basic_table.py
+++ b/examples/basic_table.py
@@ -22,16 +22,13 @@ class BasicTable(Display):
         )
 
     def neg_filter(self, value_dict):
-        rbv = value_dict['readback']
-        return rbv is None or rbv >= 0
+        return value_dict['readback'] >= 0
 
     def even_filter(self, value_dict):
-        rbv = value_dict['readback']
-        return rbv is None or int(rbv) % 2
+        return value_dict['readback'] % 2
 
     def four_filter(self, value_dict):
-        row_name = value_dict['row_name']
-        return row_name is None or len(row_name) != 4
+        return len(value_dict['row_name']) != 4
 
     def ui_filename(self):
         return os.path.join(os.path.dirname(__file__), 'basic_table.ui')

--- a/examples/basic_table.ui
+++ b/examples/basic_table.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="FilterSortWidgetTable" name="FilterSortWidgetTable">
+    <widget class="FilterSortWidgetTable" name="example_table">
      <property name="toolTip">
       <string/>
      </property>

--- a/examples/basic_table.ui
+++ b/examples/basic_table.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>372</width>
+    <height>434</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="FilterSortWidgetTable" name="FilterSortWidgetTable">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="ui_filename" stdset="0">
+      <string>basic_table_row.ui</string>
+     </property>
+     <property name="macros_filename" stdset="0">
+      <string>basic_table.json</string>
+     </property>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <item row="0" column="1"/>
+     <item row="0" column="2"/>
+     <item row="0" column="3"/>
+     <item row="0" column="4"/>
+     <item row="0" column="5"/>
+     <item row="1" column="1"/>
+     <item row="1" column="2"/>
+     <item row="1" column="3"/>
+     <item row="1" column="4"/>
+     <item row="1" column="5"/>
+     <item row="2" column="1"/>
+     <item row="2" column="2"/>
+     <item row="2" column="3"/>
+     <item row="2" column="4"/>
+     <item row="2" column="5"/>
+     <item row="3" column="1"/>
+     <item row="3" column="2"/>
+     <item row="3" column="3"/>
+     <item row="3" column="4"/>
+     <item row="3" column="5"/>
+     <item row="4" column="1"/>
+     <item row="4" column="2"/>
+     <item row="4" column="3"/>
+     <item row="4" column="4"/>
+     <item row="4" column="5"/>
+     <item row="5" column="1"/>
+     <item row="5" column="2"/>
+     <item row="5" column="3"/>
+     <item row="5" column="4"/>
+     <item row="5" column="5"/>
+     <item row="6" column="1"/>
+     <item row="6" column="2"/>
+     <item row="6" column="3"/>
+     <item row="6" column="4"/>
+     <item row="6" column="5"/>
+     <item row="7" column="1"/>
+     <item row="7" column="2"/>
+     <item row="7" column="3"/>
+     <item row="7" column="4"/>
+     <item row="7" column="5"/>
+     <item row="8" column="1"/>
+     <item row="8" column="2"/>
+     <item row="8" column="3"/>
+     <item row="8" column="4"/>
+     <item row="8" column="5"/>
+     <item row="9" column="1"/>
+     <item row="9" column="2"/>
+     <item row="9" column="3"/>
+     <item row="9" column="4"/>
+     <item row="9" column="5"/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FilterSortWidgetTable</class>
+   <extends>QTableWidget</extends>
+   <header>pcdswidgets.table</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/basic_table_row.ui
+++ b/examples/basic_table_row.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>687</width>
+    <height>40</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="row_name">
+     <property name="text">
+      <string>${row_name}</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="readback">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${row_name}?type=float&amp;init=${row_value}</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLineEdit" name="setpoint">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${row_name}</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pcdswidgets/designer.py
+++ b/pcdswidgets/designer.py
@@ -1,5 +1,6 @@
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
+from .table import FilterSortWidgetTable
 from .vacuum.gauges import RoughGauge, HotCathodeGauge, ColdCathodeGauge
 from .vacuum.others import RGA
 from .vacuum.pumps import IonPump, TurboPump, ScrollPump, GetterPump
@@ -11,6 +12,10 @@ from .vacuum.valves import (PneumaticValve, FastShutter, NeedleValve,
 from .vacuum.base import PCDSSymbolBase
 
 BasePlugin = qtplugin_factory(PCDSSymbolBase, group="PCDS Symbols")
+
+# Table
+FilterSortWidgetTablePlugin = qtplugin_factory(FilterSortWidgetTable,
+                                               group="PCDS Utilities")
 
 # Valves
 PCDSPneumaticValvePlugin = qtplugin_factory(PneumaticValve,

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -427,7 +427,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         else:
             self.showRow(row)
 
-    def activate_filter(self, active: bool, filter_name: str) -> None:
+    def activate_filter(self, filter_name: str, active: bool) -> None:
         """
         Activate or deactivate a filter by name.
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -36,6 +36,7 @@ class FilterSortWidgetTable(QTableWidget):
         self._filters = {}
         self._initial_sort_header = 'index'
         self._initial_sort_ascend = True
+        self._hide_headers = []
 
         # Table settings
         self.setShowGrid(True)
@@ -224,6 +225,8 @@ class FilterSortWidgetTable(QTableWidget):
         sort_menu = menu.addMenu('Sorting')
         for header_name in self._header_map.keys():
             if header_name == 'widget':
+                continue
+            if header_name in self.hide_headers_in_menu:
                 continue
             inner_menu = sort_menu.addMenu(header_name.lower())
             asc = inner_menu.addAction('Ascending')
@@ -424,6 +427,17 @@ class FilterSortWidgetTable(QTableWidget):
         """
         self.sort_table(self.initial_sort_header, self.initial_sort_ascending)
 
+    @QtCore.Property('QStringList')
+    def hide_headers_in_menu(self):
+        """
+        A list of headers that we don't want to see in the sort menu.
+        """
+        return self._hide_headers
+
+    @hide_headers_in_menu.setter
+    def hide_headers_in_menu(self, headers):
+        self._hide_headers = headers
+
     def sort_table(self, header, ascending):
         """
         Rearrange the ordering of the table based on any of the value fields.
@@ -468,7 +482,7 @@ class FilterSortWidgetTable(QTableWidget):
         for row in range(self.rowCount()):
             header.moveSection(header.visualIndex(row), row)
 
-    @QtCore.Property(bool)
+    @QtCore.Property(bool, designable=False)
     def configurable(self):
         """
         Whether or not the table can be manipulated from the UI.
@@ -476,7 +490,7 @@ class FilterSortWidgetTable(QTableWidget):
         If True, the table rows can be dragged/dropped/rearranged.
         If False, the table rows can no longer be selected.
 
-        This begins as False if unset.
+        This begins as False if unset and can be changed in the context menu.
         """
         return self._configurable
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -392,7 +392,16 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
             show_row = []
             for filt_info in self._filters.values():
                 if filt_info.active:
-                    show_row.append(filt_info.filter_func(values))
+                    try:
+                        should_show = filt_info.filter_func(values)
+                    except Exception:
+                        logger.debug(
+                            'Error in filter function %s',
+                            filt_info.name,
+                            exc_info=True,
+                        )
+                        should_show = True
+                    show_row.append(should_show)
                 else:
                     # If inactive, record it as unfiltered/shown
                     show_row.append(True)

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -408,7 +408,9 @@ class FilterSortWidgetTable(QTableWidget):
         col = self._header_map[header]
         self.sortItems(col, order)
         if not self.isSortingEnabled():
+            # This triggers a sort
             self.setSortingEnabled(True)
+            # This prevents further sorting updates
             self.setSortingEnabled(False)
 
     def menu_sort(self, checked, header, ascending):

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -13,8 +13,6 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 
-FilterFunc = Callable[[dict[str, Any]], bool]
-
 
 class FilterSortWidgetTable(QtWidgets.QTableWidget):
     """
@@ -334,7 +332,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
     def add_filter(
         self,
         filter_name: str,
-        filter_func: FilterFunc,
+        filter_func: Callable[[dict[str, Any]], bool],
         active: bool = True
     ) -> None:
         """
@@ -667,6 +665,6 @@ class ChannelTableWidgetItem(QtWidgets.QTableWidgetItem):
 
 @dataclasses.dataclass
 class FilterInfo:
-    filter_func: FilterFunc
+    filter_func: Callable[[dict[str, Any]], bool]
     active: bool
     name: str

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -1,0 +1,246 @@
+import logging
+import simplejson as json
+
+from pydm.widgets import PyDMEmbeddedDisplay
+from pydm.widgets.channel import PyDMChannel
+from PyQt5.QtGui import QTableWidget, QTableWidgetItem
+from qtpy import QtCore
+
+logger = logging.getLogger(__name__)
+
+
+class FilterSortWidgetTable(QTableWidget):
+    """
+    Displays repeated widgets that are sortable and filterable.
+
+    This will allow you to sort or filter based on macros and based on the
+    values in each pydm widget.
+    """
+    def __init__(self, *args,  **kwargs):
+        super().__init__(*args, **kwargs)
+        self._ui_filename = None
+        self._macros_filename = None
+        self._dummy_widget = PyDMEmbeddedDisplay(parent=self)
+        self._dummy_widget.hide()
+        self._dummy_widget.loadWhenShown = False
+        self._macros = []
+        self._channel_headers = []
+        self._macro_headers = []
+        self._channels = []
+        self._filters = {}
+
+        # Table settings
+        self.setShowGrid(True)
+        self.setSortingEnabled(True)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().hide()
+        self.verticalHeader().hide()
+
+        self._watching_cells = False
+
+    def channels(self):
+        return self._channels
+
+    @QtCore.Property(str)
+    def ui_filename(self):
+        return self._ui_filename
+
+    @ui_filename.setter
+    def ui_filename(self, filename):
+        self._ui_filename = filename
+        self.reload_ui_file()
+        self.reinit_table()
+
+    def reload_ui_file(self):
+        try:
+            self._dummy_widget.filename = self.ui_filename
+        except Exception:
+            logger.exception('')
+        # Let's find all the widgets with channels and save their names
+        self._channel_headers = []
+        for widget in self._dummy_widget.embedded_widget.children():
+            try:
+                ch = widget.channels()
+            except Exception:
+                # It is expected that some widgets do not have channels
+                continue
+            if ch:
+                self._channel_headers.append(widget.objectName())
+
+    # file contains json list of dicts
+    @QtCore.Property(str)
+    def macros_filename(self):
+        return self._macros_filename
+
+    @macros_filename.setter
+    def macros_filename(self, filename):
+        self._macros_filename = filename
+        self.reload_macros_file()
+
+    def reload_macros_file(self):
+        if not self.macros_filename:
+            return
+        try:
+            with open(self.macros_filename, 'r') as fd:
+                macros = json.load(fd)
+            self.set_macros(macros)
+        except Exception:
+            logger.exception('')
+            return
+
+    def set_macros(self, macros_list):
+        self._macros = macros_list
+        self._macro_headers = list(self._macros[0].keys())
+        self.reinit_table()
+
+    def reinit_table(self):
+        if self._watching_cells:
+            self.cellChanged.disconnect(self.handle_item_changed)
+            self._watching_cells = False
+        for channel in self._channels:
+            channel.disconnect()
+            self._channels = []
+        self.clear()
+        self.clearContents()
+        self.setRowCount(0)
+        if not self._macros and self._channel_headers:
+            return
+        # Column 1 displays widget, 2 is index, the rest hold values
+        ncols = 2 + len(self._channel_headers) + len(self._macro_headers)
+        self.setColumnCount(ncols)
+        for col in range(1, ncols):
+            self.hideColumn(col)
+        for macros in self._macros:
+            widget = PyDMEmbeddedDisplay(parent=self)
+            widget.macros = json.dumps(macros)
+            widget.filename = self.ui_filename
+            widget.loadWhenShown = False
+            widget.disconnectWhenHidden = False
+
+            row_position = self.rowCount()
+            self.insertRow(row_position)
+
+            # Put the widget into the table
+            self.setCellWidget(row_position, 0, widget)
+            self.setRowHeight(row_position, widget.height())
+
+            # Put the index into the table
+            item = ChannelTableWidgetItem(
+                header='index',
+                default=row_position,
+                )
+            self.setItem(row_position, 1, item)
+            # Put the macros into the table
+            index = 2
+            for key, value in macros.items():
+                item = ChannelTableWidgetItem(
+                    header=key,
+                    default=value,
+                    )
+                self.setItem(row_position, index, item)
+                index += 1
+            # Set up the data columns and the channels
+            for header in self._channel_headers:
+                widget = self.findChild(QtCore.QObject, header)
+                item = ChannelTableWidgetItem(
+                    header=header,
+                    channel=widget.channel,
+                    )
+                self.setItem(row_position, index, item)
+                self._channels.append(item.pydm_channel)
+                index += 1
+
+        self._watching_cells = True
+        self.cellChanged.connect(self.handle_item_changed)
+        self.update_all_filters()
+
+    def get_row_values(self, row):
+        values = {'connected': True}
+        for col in range(1, self.columnCount()):
+            item = self.item(row, col)
+            values[item.header] = item.get_value()
+            if not item.connected:
+                values['connected'] = False
+        return values
+
+    def add_filter(self, filter_name, filt):
+        # Filters take in a dict of values from header to value
+        # Return True to show, False to hide
+        self._filters[filter_name] = filt
+        self.update_all_filters()
+
+    def update_all_filters(self):
+        if self._filters:
+            for row in range(self.rowCount()):
+                self.update_filter(row)
+
+    def update_filter(self, row):
+        if self._filters:
+            values = self.get_row_values(row)
+            show_row = []
+            for filt in self._filters.values():
+                show_row.append(filt(values))
+            if all(show_row):
+                self.showRow(row)
+            else:
+                self.hideRow(row)
+
+    def handle_item_changed(self, row, col):
+        self.update_filter(row)
+
+
+class ChannelTableWidgetItem(QTableWidgetItem):
+    """
+    QTableWidgetItem that gets values from a PyDMChannel
+
+    Parameters
+    ----------
+    header : str
+        The name of the header of the column
+    default : any, optional
+        Starting value for the cell
+    channel : str, optional
+        PyDM channel address for value and connection updates.
+    """
+    def __init__(self, header, default=None, channel=None, parent=None):
+        super().__init__(parent)
+        self.header = header
+        if default is None:
+            self._value = None
+        else:
+            self.update_value(default)
+        self.channel = channel
+        self.connected = False
+        self._type = None
+        if channel is not None:
+            self.pydm_channel = PyDMChannel(
+                channel,
+                value_slot=self.update_value,
+                connection_slot=self.update_connection,
+                )
+            self.pydm_channel.connect()
+
+    def update_value(self, value):
+        """
+        Store the value for sorting and display in the table if visible
+        """
+        self._value = value
+        self.setText(str(value))
+
+    def update_connection(self, connected):
+        """
+        When our PV connects or disconnects, store the state as an attribute.
+        """
+        self.connected = connected
+
+    def get_value(self):
+        return self._value
+
+    def __lt__(self, other):
+        # Make sure None sorts as greatest
+        if self.get_value() is None:
+            return False
+        elif other.get_value is None:
+            return True
+        return self.get_value() < other.get_value()
+

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -39,7 +39,6 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
     _configurable: bool
     _watching_cells: bool
 
-
     def __init__(self, *args,  **kwargs):
         super().__init__(*args, **kwargs)
         self._ui_filename = None
@@ -97,7 +96,10 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         try:
             self.template_widget.filename = self.ui_filename
         except Exception:
-            logger.exception("Reloading the UI file %s failed", self.ui_filename)
+            logger.exception(
+                "Reloading the UI file %s failed",
+                self.ui_filename,
+            )
             return
         # Let's find all the widgets with channels and save their names
         self._channel_headers = []
@@ -154,7 +156,11 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
             have the same keys or this will not work properly.
         """
         self._macros = macros_list
-        self._macro_headers = list(self._macros[0].keys()) if self._macros else []
+        self._macro_headers = (
+            list(self._macros[0].keys())
+            if self._macros
+            else []
+        )
         self.reinit_table()
 
     def reinit_table(self) -> None:

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -339,7 +339,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         Add a new visibility filter to the table.
 
         Filters are functions with the following signature:
-        filt(values: dict[str, Any]) -> bool
+        ``filt(values: dict[str, Any]) -> bool``
         Where values is the output from get_row_values,
         and the boolean return value is True if the row should be displayed.
         If we have multiple filters, we need all of them to be True to display

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -469,6 +469,11 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         if not is_qt_designer():
             # Do a sort after a short timer
             # HACK: this is because it doesn't work if done immediately
+            # This is due to some combination of qt designer properties being
+            # applied in some random order post-__init__ combined with it
+            # taking a short bit of time for the items to be ready to sort.
+            # Some items will never connect and never be ready to sort,
+            # so for now we'll do a best-effort one-second wait.
             timer = QtCore.QTimer(parent=self)
             timer.singleShot(1000, self.initial_sort)
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -36,7 +36,7 @@ class FilterSortWidgetTable(QTableWidget):
         self.setSortingEnabled(True)
         self.setSelectionMode(self.NoSelection)
         self.horizontalHeader().setStretchLastSection(True)
-        self.verticalHeader().hide()
+        self.horizontalHeader().hide()
 
         self.configurable = False
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -504,12 +504,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         else:
             order = QtCore.Qt.DescendingOrder
         col = self._header_map[header]
-        self.sortItems(col, order)
-        if not self.isSortingEnabled():
-            # This triggers a sort
-            self.setSortingEnabled(True)
-            # This prevents further sorting updates
-            self.setSortingEnabled(False)
+        self.sortByColumn(col, order)
 
     def menu_sort(self, checked: bool, header: str, ascending: bool):
         """

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -222,7 +222,8 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
                     )
                 self.setItem(row_position, index, item)
                 self._header_map[header] = index
-                self._channels.append(item.pydm_channel)
+                if item.pydm_channel is not None:
+                    self._channels.append(item.pydm_channel)
                 index += 1
 
         self._watching_cells = True
@@ -563,6 +564,11 @@ class ChannelTableWidgetItem(QtWidgets.QTableWidgetItem):
         Only update the table if the change is more than the deadband.
         This can help make large tables less resource-hungry.
     """
+    header: str
+    channel: Optional[str]
+    deadband: float
+    pydm_channel: Optional[PyDMChannel]
+
     def __init__(
         self,
         header: str,
@@ -578,6 +584,7 @@ class ChannelTableWidgetItem(QtWidgets.QTableWidgetItem):
         self.deadband = deadband
         if channel is None:
             self.update_connection(True)
+            self.pydm_channel = None
         else:
             self.update_connection(False)
             self.pydm_channel = PyDMChannel(

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -1,20 +1,18 @@
 import dataclasses
 import functools
 import logging
-import numbers
-import simplejson as json
+import json
 import typing
 
 from pydm.utilities import is_qt_designer
 from pydm.widgets import PyDMEmbeddedDisplay
 from pydm.widgets.channel import PyDMChannel
-from PyQt5.QtGui import QTableWidget, QTableWidgetItem
 from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 
 
-class FilterSortWidgetTable(QTableWidget):
+class FilterSortWidgetTable(QtWidgets.QTableWidget):
     """
     Displays repeated widgets that are sortable and filterable.
 
@@ -512,7 +510,7 @@ class FilterSortWidgetTable(QTableWidget):
         self.configurable = conf
 
 
-class ChannelTableWidgetItem(QTableWidgetItem):
+class ChannelTableWidgetItem(QtWidgets.QTableWidgetItem):
     """
     QTableWidgetItem that gets values from a PyDMChannel
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -320,12 +320,21 @@ class FilterSortWidgetTable(QTableWidget):
             If True, we'll sort in ascending order. If False, we'll sort in
             descending order.
         """
+        self.reset_manual_sort()
         if ascending:
             order = QtCore.Qt.AscendingOrder
         else:
             order = QtCore.Qt.DescendingOrder
         col = self._header_map[header]
         self.sortItems(col, order)
+
+    def reset_manual_sort(self):
+        """
+        Rearrange the table to undo all manual drag/drop sorting.
+        """
+        header = self.verticalHeader()
+        for row in range(self.rowCount()):
+            header.moveSection(header.visualIndex(row), row)
 
     @QtCore.Property(bool)
     def configurable(self):

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -242,7 +242,7 @@ class ChannelTableWidgetItem(QTableWidgetItem):
         # Make sure None sorts as greatest
         if self.get_value() is None:
             return False
-        elif other.get_value is None:
+        elif other.get_value() is None:
             return True
         return self.get_value() < other.get_value()
 

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -112,7 +112,6 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
             if ch:
                 self._channel_headers.append(widget.objectName())
 
-    # file contains json list of dicts
     @QtCore.Property(str)
     def macros_filename(self) -> str:
         """

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -141,10 +141,10 @@ class FilterSortWidgetTable(QTableWidget):
                 index += 1
             # Set up the data columns and the channels
             for header in self._channel_headers:
-                widget = self.findChild(QtCore.QObject, header)
+                source = widget.findChild(QtCore.QObject, header)
                 item = ChannelTableWidgetItem(
                     header=header,
-                    channel=widget.channel,
+                    channel=source.channel,
                     )
                 self.setItem(row_position, index, item)
                 self._channels.append(item.pydm_channel)
@@ -210,9 +210,11 @@ class ChannelTableWidgetItem(QTableWidgetItem):
         else:
             self.update_value(default)
         self.channel = channel
-        self.connected = False
         self._type = None
-        if channel is not None:
+        if channel is None:
+            self.connected = True
+        else:
+            self.connected = False
             self.pydm_channel = PyDMChannel(
                 channel,
                 value_slot=self.update_value,

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -100,6 +100,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
             self.template_widget.filename = self.ui_filename
         except Exception:
             logger.exception("Reloading the UI file %s failed", self.ui_filename)
+            return
         # Let's find all the widgets with channels and save their names
         self._channel_headers = []
         for widget in self.template_widget.embedded_widget.children():

--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -99,7 +99,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         try:
             self.template_widget.filename = self.ui_filename
         except Exception:
-            logger.exception('')
+            logger.exception("Reloading the UI file %s failed", self.ui_filename)
         # Let's find all the widgets with channels and save their names
         self._channel_headers = []
         for widget in self.template_widget.embedded_widget.children():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the `FilterSortWidgetTable` widget. This widget allows us to repeat a template generically in a table form, and handle things like sorting and filtering in a re-usable way.

Here's a screenshot of the TMO screen I am working on that uses this widget:

![image](https://user-images.githubusercontent.com/10647860/126833645-b4603dd4-e78c-4d04-83e5-fd45040c4eae.png)

Features:

- [x] Allow a repeated widget from a template and macros
- [x] Dynamically allow sorting on any value
- [x] Allow the user to register filters and enable/disable them live
- [x] Allow the user to manually rearrange the rows of the table (check the configure box)
- [ ] Allow the user to hide/show rows individually
- [ ] Allow the user to save/load the table arrangement
- [ ] Support resizing to increase the size of the internal widgets (can we do this easily?)
- [ ] Unit tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a common motif and we should be able to re-use it in multiple contexts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only interactiveley so far

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only docstrings so far

<!--
## Screenshots (if appropriate):
-->
