### PR TITLE
MAINT: setWidth requires an int in py310

### DIFF
--- a/pcdswidgets/icons/base.py
+++ b/pcdswidgets/icons/base.py
@@ -231,7 +231,7 @@ class BaseSymbolIcon(QWidget):
         if new_width < 0:
             return
         if new_width != self._pen_width:
-            self._pen_width = new_width
+            self._pen_width = int(new_width)
             self._pen.setWidth(self._pen_width)
             self.update()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Force the setter here to store an `int` so that `setWidth` gets an `int`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The python 3.10 test suite fails on setWidth receiving floats.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the test suite offline

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
