### PR TITLE
Allow for custom ui file to be open when widget icon is pressed.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -7,8 +7,7 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy.QtCore import Q_ENUMS, Property, QSize
 from qtpy.QtGui import QCursor, QPainter
 from qtpy.QtWidgets import (QFrame, QHBoxLayout, QSizePolicy, QStyle,
-                            QStyleOption, QVBoxLayout, QWidget, QStackedWidget,
-                            QComboBox, QTabWidget)
+                            QStyleOption, QVBoxLayout, QWidget, QTabWidget)
 
 from ..utils import refresh_style
 

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -7,7 +7,7 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy.QtCore import Q_ENUMS, Property, QSize
 from qtpy.QtGui import QCursor, QPainter
 from qtpy.QtWidgets import (QFrame, QHBoxLayout, QSizePolicy, QStyle,
-                            QStyleOption, QVBoxLayout, QWidget, QTabWidget)
+                            QStyleOption, QVBoxLayout, QWidget)
 
 from ..utils import refresh_style
 
@@ -443,6 +443,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         try:
             import typhos
             from pydm.widgets import PyDMEmbeddedDisplay
+            from qtpy.QtWidgets import QTabWidget
 
         except ImportError:
             logger.error('Typhos not installed. Cannot create display.')

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -82,9 +82,9 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self.update_status_tooltip()
 
 
-        self._ui_path = []
-        self._ui_macros = []
-        self._ui_titles = []
+        self.ui_file_path = []
+        self.ui_file_macros = []
+        self.ui_file_titles = []
 
         self.tabWidget = None
         self.embeddedDisplay = None
@@ -453,24 +453,24 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._expert_display = display
         display.destroyed.connect(self._cleanup_expert_display)
 
-        if len(self._ui_path) > 0:
+        if len(self.ui_file_path) > 0:
             self.tabWidget = QTabWidget()
             self.embeddedDisplay = list()
             self.tabWidget.setTabPosition(2)
             self.tabWidget.addTab(display, "Typhos")
 
-            for i, files in enumerate(self._ui_path):
+            for i, files in enumerate(self.ui_file_path):
                 embedded = PyDMEmbeddedDisplay()
 
-                if i >= len(self._ui_titles):
+                if i >= len(self.ui_file_titles):
                     title = files
                 else:
-                    title = self._ui_titles[i]
+                    title = self.ui_file_titles[i]
 
-                if i >= len(self._ui_macros):
+                if i >= len(self.ui_file_macros):
                     macros = ''
                 else:
-                    macros = self._ui_macros[i]
+                    macros = self.ui_file_macros[i]
 
                 embedded.set_macros_and_filename(files, macros) 
                 self.tabWidget.addTab(embedded, title)
@@ -484,30 +484,30 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
     
     @Property('QStringList')
     def ui_path(self):
-        return self._ui_path
+        return self.ui_file_path
 
     @ui_path.setter
     def ui_path(self, path):
-        if path != self._ui_path:
-            self._ui_path = path
+        if path != self.ui_file_path:
+            self.ui_file_path = path
 
     @Property('QStringList')
     def ui_macros(self):
-        return self._ui_macros
+        return self.ui_file_macros
 
     @ui_macros.setter
     def ui_macros(self, macros):
         if macros != self.ui_macros:
-            self._ui_macros = macros
+            self.ui_file_macros = macros
 
     @Property('QStringList')
     def titles(self):
-        return self._ui_titles
+        return self.ui_file_titles
 
     @titles.setter
     def titles(self, titles):
-        if titles != self._ui_titles:
-            self._ui_titles = titles
+        if titles != self.ui_file_titles:
+            self.ui_file_titles = titles
 
 
     def _cleanup_expert_display(self, *args, **kwargs):

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -454,7 +454,7 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self._expert_display = display
         display.destroyed.connect(self._cleanup_expert_display)
 
-        if self._ui_path is not None:
+        if len(self._ui_path) > 0:
             self.tabWidget = QTabWidget()
             self.embeddedDisplay = list()
             self.tabWidget.setTabPosition(2)

--- a/pcdswidgets/vacuum/base.py
+++ b/pcdswidgets/vacuum/base.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from itertools import zip_longest
 
 from pydm.utilities import IconFont, remove_protocol
 from pydm.widgets.base import PyDMPrimitiveWidget
@@ -8,12 +9,12 @@ from pydm.widgets.embedded_display import PyDMEmbeddedDisplay
 from qtpy.QtCore import Q_ENUMS, Property, QSize
 from qtpy.QtGui import QCursor, QPainter
 from qtpy.QtWidgets import (QFrame, QHBoxLayout, QSizePolicy, QStyle,
-                            QStyleOption, QVBoxLayout, QWidget, QTabWidget)
+                            QStyleOption, QTabWidget, QVBoxLayout, QWidget)
 
-from itertools import zip_longest
 from ..utils import refresh_style
 
 logger = logging.getLogger(__name__)
+
 
 class ContentLocation:
     """
@@ -82,15 +83,13 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
         self.setup_icon()
         self.assemble_layout()
         self.update_status_tooltip()
-
-
         self.ui_file_paths = []
+
         self.ui_file_macros = []
         self.ui_file_titles = []
 
         self.tab_widget = None
         self.embedded_displays = list()
-
 
     def sizeHint(self):
         """
@@ -471,15 +470,15 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
                 title = title or file_path
                 macros = macros or ''
 
-                embedded.set_macros_and_filename(file_path, macros) 
+                embedded.set_macros_and_filename(file_path, macros)
                 self.tab_widget.addTab(embedded, title)
                 self.embedded_displays.append(embedded)
 
             self.tab_widget.show()
 
         elif display:
-            display.show() 
-    
+            display.show()
+
     @Property('QStringList')
     def ui_paths(self):
         return self.ui_file_paths
@@ -506,7 +505,6 @@ class PCDSSymbolBase(QWidget, PyDMPrimitiveWidget, ContentLocation):
     def ui_titles(self, titles):
         if titles != self.ui_file_titles:
             self.ui_file_titles = titles
-
 
     def _cleanup_expert_display(self, *args, **kwargs):
         self._expert_display = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When device widget icon is pressed a predefined screen will appear as a tab in the typhos screen. If no screen is defined typhos works as usual.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows for more information to be displayed about a device, such as interlock information.
https://jira.slac.stanford.edu/browse/LCLSECSD-1735
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Made a test screen that contains a pcds widget and checked the behavior when the icon is pressed. 
Tested variation of inputs in designer properties.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
