### PR TITLE
ENH: add eps widget for EPS PLC structure

### DIFF
--- a/pcdswidgets/eps_byteindicator.py
+++ b/pcdswidgets/eps_byteindicator.py
@@ -1,0 +1,155 @@
+from pydm.widgets import PyDMByteIndicator, PyDMChannel
+from qtpy.QtCore import Property, Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QTabWidget, QVBoxLayout, QWidget
+
+
+class ByteIndicator_NegativeNums(PyDMByteIndicator):
+    """
+        Modified Byte Indicator calss. Overides update_indicators
+            fucntion to allow for negative numbers to work for ByteIndicator
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def update_indicators(self):
+        if self._shift < 0:
+            value = int(self.value) << abs(self._shift)
+        else:
+            value = int(self.value) >> self._shift
+
+        bits = [(value >> i) & 1
+                for i in range(self._num_bits)]
+        for bit, indicator in zip(bits, self._indicators):
+            if self._connected:
+                if self._alarm_state == 3:
+                    c = self._invalid_color
+                else:
+                    c = self._on_color if bit else self._off_color
+            else:
+                c = self._disconnected_color
+            indicator.setColor(c)
+
+
+class EPSByteIndicator(QWidget):
+    """
+        Widget for displaying EPS interlocks
+    """
+
+    _qt_designer_ = {
+        "group": "PCDS Utilities",
+        "is_container": False,
+    }
+
+    template_widget = ByteIndicator_NegativeNums
+
+    _channels_prefix = None
+    _value_channel = None
+    _label_channel = None
+
+    _value_pv = ""
+    _label_pv = ""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.template_widget = ByteIndicator_NegativeNums()
+        layout = QVBoxLayout()
+        layout.addWidget(self.template_widget)
+        self.setLayout(layout)
+
+    def value_change(self, new_value):
+        """
+            Callback function when value changes
+        """
+        self.template_widget.value = new_value
+        self.template_widget.update_indicators()
+
+    def label_change(self, new_labels):
+        """
+            Callback function when the lables change
+        """
+        labels = "".join(map(chr, new_labels))
+        labels = labels.partition('\x00')
+        labels = labels[0].split(';')
+
+        self.template_widget.numBits = len(labels)
+        self.template_widget.labels = labels
+        self.template_widget.update_indicators()
+
+    @Property(str)
+    def channel(self):
+        """
+            PV of Base EPS strcture
+        """
+        return self._channels_prefix
+
+    @channel.setter
+    def channel(self, ch):
+        """
+            Set PV of Base EPS strcture
+        """
+        if ch != self._channels_prefix:
+            self._value_pv = ch + ":EPS:nFlags_RBV"
+            self._label_pv = ch + ":EPS:sFlagDesc_RBV"
+
+            _value_channel = PyDMChannel(address=self._value_pv,
+                                         value_slot=self.value_change)
+
+            _label_channel = PyDMChannel(address=self._label_pv,
+                                         value_slot=self.label_change)
+            try:
+                _value_channel.connect()
+                _label_channel.connect()
+            except Exception:
+                print('could not connect to PV')
+                self.template_widget._connected = False
+
+            self._channels_prefix = ch
+            self.template_widget._connected = True
+
+    @Property(bool)
+    def circles(self):
+        return self.template_widget.circles
+
+    @circles.setter
+    def circles(self, b):
+        self.template_widget.circles = b
+
+    @Property(QTabWidget.TabPosition)
+    def label_position(self):
+        return self.template_widget._label_position
+
+    @label_position.setter
+    def label_position(self, position):
+        self.template_widget._label_position = position
+        self.template_widget.rebuild_layout()
+
+    @Property(Qt.Orientation)
+    def orientation(self):
+        return self.template_widget._orientation
+
+    @orientation.setter
+    def orientation(self, orientation):
+        self.template_widget._orientation = orientation
+        self.template_widget.set_spacing()
+        self.template_widget.rebuild_layout()
+
+    @Property(QColor)
+    def OnColor(self):
+        return self.template_widget._on_color
+
+    @OnColor.setter
+    def OnColor(self, new_color):
+        if self.template_widget._on_color != new_color:
+            self.template_widget._on_color = new_color
+            self.template_widget.update_indicators()
+
+    @Property(QColor)
+    def OffColor(self):
+        return self.template_widget._off_color
+
+    @OffColor.setter
+    def OffColor(self, new_color):
+        if self.template_widget._off_color != new_color:
+            self.template_widget._off_color = new_color
+            self.template_widget.update_indicators()

--- a/pcdswidgets/eps_byteindicator.py
+++ b/pcdswidgets/eps_byteindicator.py
@@ -94,8 +94,8 @@ class EPSByteIndicator(QWidget):
         Set PV of Base EPS strcture
         """
         if ch != self._channels_prefix:
-            self._value_pv = ch + ":EPS:nFlags_RBV"
-            self._label_pv = ch + ":EPS:sFlagDesc_RBV"
+            self._value_pv = ch + ":nFlags_RBV"
+            self._label_pv = ch + ":sFlagDesc_RBV"
 
             _value_channel = PyDMChannel(address=self._value_pv,
                                          connection_slot=self.value_channel,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Widget for displaying EPS structure information as a ByteIndicator. The widget automatically sets the correct size and labels based on EPS structure PLC code, given the base PV of the EPS structure PV.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Jira Ticket](https://jira.slac.stanford.edu/browse/LCLSPC-373)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using a PLC program with the modified twincat-general and twincat-motion, a test program was written. The test program was ran on the tst-motion PLC and its associated IOC. Using these PVs the eps-widget was tested to see if the widget functioned as expected.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
<img width="708" alt="image" src="https://user-images.githubusercontent.com/55956919/221687222-0bf6c322-d8a3-456c-afaf-483aadff0f90.png">

