### PR TITLE
BUG fixing activate_filter by rearranging parameters to work with qtpy

### DIFF
--- a/pcdswidgets/table.py
+++ b/pcdswidgets/table.py
@@ -438,7 +438,7 @@ class FilterSortWidgetTable(QtWidgets.QTableWidget):
         else:
             self.showRow(row)
 
-    def activate_filter(self, filter_name: str, active: bool) -> None:
+    def activate_filter(self, active: bool, filter_name: str) -> None:
         """
         Activate or deactivate a filter by name.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
One line change, switched order of active and filter_name paramters in activate_filter from table.py.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, attempting to change the filter results in: TypeError: activate_filter() got multiple values for argument 'filter_name', presumably because filter_name is the first argument and is given by a keyword argument in the slot for the filter menu, but the pyqt gives the bool as the first positional argument, causing there to be multiple values for filter_name and none for active.

I think this is caused by the use of functools partial: the signal calls the partial object with one argument, but this is given as the first positional argument, which was already given in the creation of the object as a keyword argument. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made the change in my local repo and used pydm to create a window with a FilterSortWidgetTable. After making the change, using the filter menu worked as expected, but before it caused the above TypeError. I feel this is sufficient since it's a one-line edit and activate_filter is only used in one place. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I didn't change any documentation (the docstring already has the parameters in the "right" order)

<!--
## Screenshots (if appropriate):
-->
