### PR TITLE
FIX: EPS byte indicator designer entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ RoughGauge = "pcdswidgets.vacuum.gauges:RoughGauge"
 HotCathodeGauge = "pcdswidgets.vacuum.gauges:HotCathodeGauge"
 ColdCathodeGauge = "pcdswidgets.vacuum.gauges:ColdCathodeGauge"
 RGA = "pcdswidgets.vacuum.others:RGA"
+EPSByteIndicator = "pcdswidgets.eps_byteindicator:EPSByteIndicator"
 
 [tool.setuptools.packages.find]
 where = [ ".",]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add Qt designer entrypoint for byte indicator widget

## Motivation and Context
Closes #88 

## How Has This Been Tested?
`from pcdswidgets.eps_byteindicator import EPSByteIndicator` works successfully

## Where Has This Been Documented?
Issue #88 
