### PR TITLE
VFS Icon interlock bug

### DIFF
--- a/pcdswidgets/vacuum/valves.py
+++ b/pcdswidgets/vacuum/valves.py
@@ -289,7 +289,7 @@ class FastShutter(
         "group": "PCDS Valves",
         "is_container": False,
     }
-    _interlock_suffix = ":VAC_FAULT_OK_RBV"
+    _interlock_suffix = ":OPN_OK_RBV"
     _error_suffix = ":STATE_RBV"
     _state_suffix = ":POS_STATE_RBV"
     _command_buttons = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changed  _interlock_suffix to ':OPN_OK_RBV' in FastShutter Class. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fast shutter valve Icon falsely displays a black border, indicating an interlock failure, but it is actually permitted to open. 

https://jira.slac.stanford.edu/browse/ECSENG-523

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I used [sim-ioc](https://github.com/pcdshub/sim-ioc) to create a test IOC. Then created a test screen with the VFS icon. Changing the 'OPN_OK_RBV' PV changes the black boarder on the icon.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
