### PR TITLE
BLD: adjust name of docs-versions-menu to match conda package name

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
-docs_versions_menu
+docs-versions-menu
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery


### PR DESCRIPTION
## Description
Adjusts the name of `docs_versions_menu` to use underscores so it matches conda, and doesn't break our env building scripts

## Motivation and Context
I'm spending my time chasing an environment that doesn't want to be built

## How Has This Been Tested?
Zach showed that this should fix our extras gathering script independently.  On pip this shouldn't matter

## Where Has This Been Documented?
This PR