### PR TITLE
Adding Kashiyama Rough Pump

### DIFF
--- a/pcdswidgets/vacuum/pumps.py
+++ b/pcdswidgets/vacuum/pumps.py
@@ -348,3 +348,94 @@ class GetterPump(PCDSSymbolBase):
     @Property(ContentLocation, designable=False)
     def controlsLocation(self):
         return super().controlsLocation
+
+
+class KashiyamaPump(InterlockMixin, ErrorMixin, StateMixin, ButtonControl, PCDSSymbolBase):
+    """
+    A Symbol Widget representing a Kashiyama Dry Pump with the proper icon and
+    controls.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the symbol
+
+    Notes
+    -----
+    This widget allow for high customization through the Qt Stylesheets
+    mechanism.
+    As this widget is composed by internal widgets, their names can be used as
+    selectors when writing your stylesheet to be used with this widget.
+    Properties are also available to offer wider customization possibilities.
+
+    **Internal Components**
+
+    +-----------+--------------+---------------------------------------+
+    |Widget Name|Type          |What is it?                            |
+    +===========+==============+=======================================+
+    |interlock  |QFrame        |The QFrame wrapping this whole widget. |
+    +-----------+--------------+---------------------------------------+
+    |controls   |QFrame        |The QFrame wrapping the controls panel.|
+    +-----------+--------------+---------------------------------------+
+    |icon       |BaseSymbolIcon|The widget containing the icon drawing.|
+    +-----------+--------------+---------------------------------------+
+
+    **Additional Properties**
+
+    +-----------+-------------------------------------------------------------+
+    |Property   |Values                                                       |
+    +===========+=============================================================+
+    |interlocked|`true` or `false`                                            |
+    +-----------+-------------------------------------------------------------+
+    |error      |`true` or  `false`                                           |
+    +-----------+-------------------------------------------------------------+
+    |state      |`On`, `Accelerating` or `Off`                                |
+    +-----------+-------------------------------------------------------------+
+
+    Examples
+    --------
+
+    .. code-block:: css
+
+        KashiyamaPump[interlocked="true"] #interlock {
+            border: 5px solid red;
+        }
+        KashiyamaPump[interlocked="false"] #interlock {
+            border: 0px;
+        }
+        KashiyamaPump[error="true"] #icon {
+            qproperty-penStyle: "Qt::DotLine";
+            qproperty-penWidth: 2;
+            qproperty-brush: red;
+        }
+        KashiyamaPump[state="Accelerating"] #icon {
+            qproperty-centerBrush: red;
+        }
+
+    """
+
+    _qt_designer_ = {
+        "group": "ECS Vacuum Pumps",
+        "is_container": False,
+    }
+    _interlock_suffix = ":ILK_OK_RBV"
+    _error_suffix = ":ALARM_OK_RBV"
+    _state_suffix = ":STATE_RBV"
+    _command_suffix = ":RUN_SW"
+
+    NAME = "Scroll Pump"
+    EXPERT_OPHYD_CLASS = "pcdsdevices.pump.Kashiyama_G"
+
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(
+            parent=parent,
+            interlock_suffix=self._interlock_suffix,
+            error_suffix=self._error_suffix,
+            state_suffix=self._state_suffix,
+            command_suffix=self._command_suffix,
+            **kwargs,
+        )
+        self.icon = ScrollPumpSymbolIcon(parent=self)
+
+    def sizeHint(self):
+        return QSize(180, 80)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Copied from the existing rough pump class and changed the Ophyd class to the Kashiyama G series one (currently points to a non-existent class as I need to merge that code prior to this).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Kashiyama Neo Dry G-Series is a new device we are adding to the SDL. The IO interface adds some new PVs, making this slightly different from our standard scroll pump. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet tested

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->

## Pre-merge Checklist
- [ ] Screenshots of these widgets in designer are included above (`try_in_designer.sh`)
- [ ] Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] New/changed widgets are part of the test suite (semi-automatic)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
