### PR TITLE
Add "Fixed" and "Stretch" Widget Size Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Before getting too deep, however, please consider widget sizing:
 ### Widget Sizing
 We have some strict guidelines on widget sizing. These are established to give us some consistency in application of widgets, as well as to make it simpler to avoid resizing a widget between library releases.
 
-Device control widgets should fall into exactly one of three size classes.
-(Note: we can add more size classes if necessary).
+Device control widgets should fall into exactly one of the size classes below.
 
 To ensure sizing consistency, set the minimum and maximum sizes to values that look good throughout the range
 and are permissible sizes as recorded below.
@@ -118,11 +117,15 @@ Widgets should always be maintained to work at the original designed size, becau
 | Full | 400 px | 125 px |
 | Compact | 100 px | 75 px |
 | Row | 800 px | 50 px |
+| Fixed | Custom | Custom |
+| Stretch | Custom | Custom |
 
 Note:
 - All widgets are allowed to be smaller than the maximum of their size class by up to 20%.
 - Rows are also allowed to be double-height, e.g. 100px height.
 - Widgets that aren't control widgets (containers, etc.) should not have a maximum or a minimum size. These widgets should instead be usable at any size. There is a list in the test suite to add test exceptions for these.
+- **Fixed**  Use this when your widget doesn't fit a standard size class but should still have a fixed size following the same min/max conventions as above.
+- **Stretch** size widgets are fully scalable with no maximum size constraint. The dimensions in the name represents the minimum size. Use this when your widget should be freely resizable.
 
 
 ### Environment Setup
@@ -162,6 +165,9 @@ Widget names and ui filenames should have one to one correspondence and contain 
 - Descriptor word to differentiate this widget from other possible widgets with the same device type and size
 - Size class signifier
 
+For the standard size classes (Double, Full, Compact, Row), the size class name is the final word in the widget name.
+For the custom size classes (Fixed, Stretch), the size class and dimensions are encoded at the end of the name using the format `fixed_WxH` or `stretch_WxH` (lowercase in filenames, CamelCase in class names).
+
 For casing:
 - `.ui` filenames should be lowercase_with_underscores for ease of working with filenames.
 - Class names should use CamelCase to match qt and python naming conventions.
@@ -176,6 +182,12 @@ Examples:
    - Controls generic EPICS motor record with a thermocouple added
    - Is inspired by the classic EDM style
    - Is sized to be the "row" size
+- `camera_feed_fixed_640x480.ui` (`CameraFeedFixed640X480`)
+   - Displays a camera feed
+   - Has a fixed size of 640x480 pixels
+- `camera_overview_stretch_800x600.ui` (`CameraOverviewStretch800X600`)
+   - Shows camera overview
+   - Designed for 800x600 but can be freely resized
 
 Other guidelines:
 

--- a/pcdswidgets/tests/builder/test_entrypoint_widgets.py
+++ b/pcdswidgets/tests/builder/test_entrypoint_widgets.py
@@ -86,16 +86,31 @@ def test_widget_sizing(widget_name: str, WidgetCls: type[QWidget], qtbot):
         max_h = 250
         min_w = ratio * max_w
         min_h = ratio * max_h
+    elif "Fixed" in widget_name and "X" in widget_name.split("Fixed")[-1]:
+        dims = widget_name.split("Fixed")[-1]
+        w_str, h_str = dims.split("X", 1)
+        max_w = int(w_str)
+        max_h = int(h_str)
+        min_w = ratio * max_w
+        min_h = ratio * max_h
+    elif "Stretch" in widget_name and "X" in widget_name.split("Stretch")[-1]:
+        dims = widget_name.split("Stretch")[-1]
+        w_str, h_str = dims.split("X", 1)
+        max_w = None
+        min_w = int(w_str)
+        min_h = int(h_str)
     else:
         raise ValueError(
             f"Widget named {widget_name} does not follow naming convention: "
-            "must end with Full, Compact, or Row to signal size class."
+            "must end with Full, Compact, Row, Double, Fixed<W>X<H>, or Stretch<W>X<H> "
+            "to signal size class."
         )
 
     assert widget.minimumWidth() >= min_w, f"{widget_name}'s minimum width is too small."
-    assert widget.maximumWidth() <= max_w, f"{widget_name}'s maximum width is too large."
     assert widget.minimumHeight() >= min_h, f"{widget_name}'s minimum height is too small."
-    assert widget.maximumHeight() <= max_h, f"{widget_name}'s maximum height is too large."
+    if max_w is not None:
+        assert widget.maximumWidth() <= max_w, f"{widget_name}'s maximum width is too large."
+        assert widget.maximumHeight() <= max_h, f"{widget_name}'s maximum height is too large."
 
 
 @pytest.mark.parametrize("widget_name,WidgetCls", [elem for elem in iter_all_widgets() if elem[0] in container_widgets])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Modified the README and CI tests that enforce widget size to classes. Added two size classes.
- Fixed -> defines a custom widget size explicitly in the name  (enforces min and max size)
   -  example motor_classic_fixed_400X400.ui
- Stretch class -> define a widget designed to be expanded to fill a screen (only enforces min size)
  -  example motor_classic_stretch_400X400.ui
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following an offline conversation with "ZLLentz", there was some discussion around loosening the size restriction on widgets as long as the size was explicitly defined. This PR is my suggestion for this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
built some widgets with these size classes and made sure the test failed if sizes were not correct

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
here
## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->
NA

## Pre-merge Checklist
- [ ] Screenshots of these widgets in designer are included above (`try_in_designer.sh`)
- [ ] Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)
- [X] Code works interactively
- [X] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] New/changed widgets are part of the test suite (semi-automatic)
- [X] Test suite passes locally
- [X] Test suite passes on GitHub Actions
