### PR TITLE
MNT: remove sizing restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,28 +101,25 @@ Before getting too deep, however, please consider widget sizing:
 
 
 ### Widget Sizing
-We have some strict guidelines on widget sizing. These are established to give us some consistency in application of widgets, as well as to make it simpler to avoid resizing a widget between library releases.
+We have some loose guidelines on widget sizing. These are established to give us some consistency in application of widgets, as well as to make it simpler to avoid resizing a widget between library releases.
 
-Device control widgets should fall into exactly one of three size classes.
+Device control widgets should fall into exactly one of the following size classes, but they do not have to if there's a good reason to diverge.
 (Note: we can add more size classes if necessary).
-
-To ensure sizing consistency, set the minimum and maximum sizes to values that look good throughout the range
-and are permissible sizes as recorded below.
-It's recommended to use fixed sizing when possible because dynamic sizing is hard to implement correctly.
-
-Widgets should always be maintained to work at the original designed size, because changing this can break existing screens.
 
 | Size Class | Width | Height |
 | ---------- | ----- | -------|
-| Double| 400 px | 250 px |
+| Double | 400 px | 250 px |
 | Full | 400 px | 125 px |
 | Compact | 100 px | 75 px |
 | Row | 800 px | 50 px |
+| Stretch | Custom/Big | Custom/Big |
 
-Note:
-- All widgets are allowed to be smaller than the maximum of their size class by up to 20%.
-- Rows are also allowed to be double-height, e.g. 100px height.
-- Widgets that aren't control widgets (containers, etc.) should not have a maximum or a minimum size. These widgets should instead be usable at any size. There is a list in the test suite to add test exceptions for these.
+Note that this isn't enforced in any way.
+
+To ensure sizing consistency, set the minimum and maximum sizes to values that look good throughout your desired size range.
+It's recommended to use fixed sizing when possible because dynamic sizing is hard to implement correctly.
+
+Widgets should always be maintained to work at the original designed size, because changing this can break existing screens.
 
 
 ### Environment Setup
@@ -160,7 +157,7 @@ Widget names and ui filenames should have one to one correspondence and contain 
 
 - Type of device controlled
 - Descriptor word to differentiate this widget from other possible widgets with the same device type and size
-- Size class signifier
+- Size class signifier (or, if none are suitable, another descriptive suffix)
 
 For casing:
 - `.ui` filenames should be lowercase_with_underscores for ease of working with filenames.

--- a/pcdswidgets/tests/builder/test_entrypoint_widgets.py
+++ b/pcdswidgets/tests/builder/test_entrypoint_widgets.py
@@ -1,10 +1,8 @@
 from importlib.metadata import entry_points
 
-import pytest
 from pydm.config import ENTRYPOINT_WIDGET
-from qtpy.QtWidgets import QWidget
 
-from pcdswidgets.builder.entrypoint_finder import get_widget_entrypoint_data, iter_all_widgets
+from pcdswidgets.builder.entrypoint_finder import get_widget_entrypoint_data
 
 
 def test_entrypoint_has_all_widgets():
@@ -18,95 +16,3 @@ def test_entrypoint_has_all_widgets():
     name_and_entrypoint = get_widget_entrypoint_data()
     for name, entrypoint in name_and_entrypoint:
         assert pydm_widgets.select(name=name)[name].value == entrypoint
-
-
-container_widgets = [
-    "FilterSortWidgetTable",
-]
-
-# Don't check widgets from before we made sizing/naming standards
-exempt_widgets = [
-    "ApertureValve",
-    "CapacitanceManometerGauge",
-    "ColdCathodeComboGauge",
-    "ColdCathodeGauge",
-    "ControlOnlyValveNC",
-    "ControlOnlyValveNO",
-    "ControlValve",
-    "EPSByteIndicator",
-    "FastShutter",
-    "GetterPump",
-    "HotCathodeComboGauge",
-    "HotCathodeGauge",
-    "IonPump",
-    "NeedleValve",
-    "PneumaticValve",
-    "PneumaticValveDA",
-    "PneumaticValveNO",
-    "ProportionalValve",
-    "RGA",
-    "RightAngleManualValve",
-    "RoughGauge",
-    "ScrollPump",
-    "TurboPump",
-] + container_widgets
-
-
-@pytest.mark.parametrize(
-    "widget_name,WidgetCls", [elem for elem in iter_all_widgets() if elem[0] not in exempt_widgets]
-)
-def test_widget_sizing(widget_name: str, WidgetCls: type[QWidget], qtbot):
-    """
-    Ensure that all widgets are named and sized appropriately as per our standards.
-    """
-    widget = WidgetCls()
-    qtbot.addWidget(widget)
-    # 30% smaller is OK
-    ratio = 0.7
-
-    if widget_name.endswith("Full"):
-        max_w = 400
-        max_h = 125
-        min_w = ratio * max_w
-        min_h = ratio * max_h
-    elif widget_name.endswith("Compact"):
-        max_w = 100
-        max_h = 75
-        min_w = ratio * max_w
-        min_h = ratio * max_h
-    elif widget_name.endswith("Row"):
-        max_w = 800
-        max_h = 50
-        min_w = ratio * max_w
-        min_h = ratio * max_h
-        # Allow double rows
-        max_h = max_h * 2
-    elif widget_name.endswith("Double"):
-        max_w = 400
-        max_h = 250
-        min_w = ratio * max_w
-        min_h = ratio * max_h
-    else:
-        raise ValueError(
-            f"Widget named {widget_name} does not follow naming convention: "
-            "must end with Full, Compact, or Row to signal size class."
-        )
-
-    assert widget.minimumWidth() >= min_w, f"{widget_name}'s minimum width is too small."
-    assert widget.maximumWidth() <= max_w, f"{widget_name}'s maximum width is too large."
-    assert widget.minimumHeight() >= min_h, f"{widget_name}'s minimum height is too small."
-    assert widget.maximumHeight() <= max_h, f"{widget_name}'s maximum height is too large."
-
-
-@pytest.mark.parametrize("widget_name,WidgetCls", [elem for elem in iter_all_widgets() if elem[0] in container_widgets])
-def test_container_widget_sizing(widget_name: str, WidgetCls: type[QWidget], qtbot):
-    """
-    Ensure that container widgets have no maximum size.
-    """
-    widget = WidgetCls()
-    qtbot.addWidget(widget)
-
-    # The max size is currently 16777215
-    # Pick a smaller but still absurd number as the threshold
-    assert widget.maximumWidth() >= 100000, f"{widget_name}'s maximum width is too small."
-    assert widget.maximumHeight() >= 100000, f"{widget_name}'s maximum height is too small."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Remove tests for size constraints
- Add the "Stretch" size class name from #100 
- Update the readme to make these more optional

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Lots of widgets are being made that should not or cannot match the size classes
- There are definitely better ways to enforce "the widget size should not change" (e.g. code review)
- We can revisit later and put formal tests in if needed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- This is removing tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- Here and in the readme

## Pre-merge Checklist
- [ ] ~Screenshots of these widgets in designer are included above (`try_in_designer.sh`)~
- [ ] ~Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)~
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [ ] ~New/changed widgets are part of the test suite (semi-automatic)~
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
