### PR TITLE
MNT: only include pyqtProperty import if it is used to avoid lint errors

### DIFF
--- a/pcdswidgets/builder/ui_base_widget.j2
+++ b/pcdswidgets/builder/ui_base_widget.j2
@@ -20,11 +20,12 @@ widget_to_pre_templ_lists: dict[str, list[tuple[str, list[str]]]]
 from pcdswidgets.builder.designer_widget import DesignerWidget
 from .{{ ui_name.removesuffix(".ui") }}_form import *
 
+{% if macro_names %}
 try:
     from qtpy.QtCore import pyqtProperty
 except ImportError:
     from qtpy.QtCore import Property as pyqtProperty  # type: ignore
-
+{% endif %}
 
 class {{ base_cls }}(DesignerWidget):
 {% for widget in widget_names %}

--- a/pcdswidgets/generated/imaging/common/colormap_intesity_control_full_base.py
+++ b/pcdswidgets/generated/imaging/common/colormap_intesity_control_full_base.py
@@ -21,11 +21,6 @@ from pcdswidgets.builder.designer_widget import DesignerWidget
 
 from .colormap_intesity_control_full_form import *
 
-try:
-    from qtpy.QtCore import pyqtProperty  # noqa: F401
-except ImportError:
-    pass  # type: ignore
-
 
 class ColormapIntesityControlFullBase(DesignerWidget):
     ui_form = Ui_Form


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In `ui_base_widget.j2`, we had an import that was always included, even when it wasn't used, causing some linting/CI issues. A simple resolution is to no longer include the import when it is not needed.

Therefore, I surrounded the import in an `if` block and matched it to the same variable that is iterated through below when the import is used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Errors/warnings on `make`, CI issues, general annoyance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively plus the unit tests pass locally

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->

## Pre-merge Checklist
- [ ] ~Screenshots of these widgets in designer are included above (`try_in_designer.sh`)~
- [ ] ~Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)~
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] New/changed widgets are part of the test suite (semi-automatic)
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
