### PR TITLE
CI: GHA SHA test in advance of enterprise requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      exclude:
+      - pcdshub/pcds-ci-helpers/*

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   standard:
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@daab22df5db812fade2f720068a8e49ae0df1a69
     secrets: inherit
     with:
       # The workflow needs to know the package name.  This can be determined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Update the pcds-ci-helpers reference to use a slightly older SHA (to see if dependabot will update it for us)
Add a dependabot config to keep the SHA periodically synchronized

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At the start of July this will be required or else all GHA builds will no longer run
https://jira.slac.stanford.edu/browse/ECS-10557

I want to get this working manually on a few repositories before trying to automate the update everywhere
In pcdswidgets, I will check that setting to an older SHA "just works" and that dependabot will automatically update it.

I'm picking a monthly update so we don't get crazy spam PRs from dependabot too often, but we still stay up-to-date.
A repo that needs an immediate update can force dependabot to run early via the github ui.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested dependabot lightly over in pcds-ci-helpers
I'm planning to use the results of this CI run as a green light that this is the correct way to do an update

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only


## Pre-merge Checklist
- [ ] ~Screenshots of these widgets in designer are included above (`try_in_designer.sh`)~
- [ ] ~Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)~
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] New/changed widgets are part of the test suite (semi-automatic)
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
