### PR TITLE
FIX: still update the config file property even if invalid

### DIFF
--- a/pcdswidgets/common/toolbar/yaml_toolbar.py
+++ b/pcdswidgets/common/toolbar/yaml_toolbar.py
@@ -65,11 +65,11 @@ class YamlToolbar(QtWidgets.QWidget):
         file : str
             The absolute path to the config file.
         """
+        self._config_file = file
         if not file:
             return
         if not os.path.isfile(file):
             return
-        self._config_file = file
         with open(file) as tf:
             full_config = yaml.full_load(tf)
         self._assemble_tabs(full_config)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In the yaml toolbar, if the user provides an invalid filepath, still save it as the property value even if we can't use it to set up the widget.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables us to use macros and it enables us to save half-complete paths. Without this change, any invalid path is immediately wiped and cannot be saved in designer, leading to some frustration in the editor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works as expected interactively, see screenshots

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to the catalog

## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->
In designer: partial/incorrect filename is no longer rejected
<img width="640" height="257" alt="image" src="https://github.com/user-attachments/assets/9361282d-7a56-4b48-98d4-9df8456bb2ad" />

In designer: full filename loads the toolbar
<img width="742" height="265" alt="image" src="https://github.com/user-attachments/assets/ed49a154-33cc-4344-87c2-ba42a703be8a" />

In pydm: still looks good
<img width="469" height="236" alt="image" src="https://github.com/user-attachments/assets/381cc714-f29f-4b90-83fc-57e7d41a248a" />

## Pre-merge Checklist
- [x] Screenshots of these widgets in designer are included above (`try_in_designer.sh`)
- [x] Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)
- [x] Description and screenshot and of these widgets working are added to the ECS Widget Catalog https://confluence.slac.stanford.edu/spaces/PCDS/pages/716925985/ECS+UI+UX+pcdswidgets+Widget+Catalog
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] New/changed widgets are part of the test suite (semi-automatic)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions