### PR TITLE
FIX: default related display to open in new window for yaml toolbars

### DIFF
--- a/pcdswidgets/common/toolbar/yaml_toolbar.py
+++ b/pcdswidgets/common/toolbar/yaml_toolbar.py
@@ -139,6 +139,10 @@ class YamlToolbar(QtWidgets.QWidget):
             btn = PyDMRelatedDisplayButton()
             btn.showIcon = False
             btn.setText(text)
+            # Normal default is to replace the current window, but this isn't good for toolbars.
+            # It's also not how these behaved in lucid, where they always opened in a new windows
+            # because there was no PyDMMainWindow to fill.
+            btn.setOpenInNewWindow(True)
         elif tp == "dock":
             btn = TabDockButton()
             btn.setText(text)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The default behavior for a related display button in pydm is to replace the open screen.
This makes it so that related display buttons in the yaml toolbar will open in a new windows instead by default.
This should still be overridable in the yaml as it was before (but nobody did this).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is the behavior that lucid has because, with no pydm main window, the related display buttons are unable to replace the contents of the current pydm main windows.

Since these are now run within a pydm main window, this adjustment restores the previous "meaning" of the configuration file.

In general, this default makes much more sense for home screens (and screens in general imo) and this makes it so we won't need to redo all of our yaml configs to specify that we want to open in new windows.

See https://slac.slack.com/archives/C0B201ZDAD7/p1784766057379549?thread_ts=1784569483.513939&cid=C0B201ZDAD7

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only: seems to work

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->
QRIX vacuum now opens in a new window from the pydm version of rix home:
<img width="1477" height="572" alt="image" src="https://github.com/user-attachments/assets/66f3273a-1213-4e03-ab65-da857595ccab" />

Widget still looks the same in designer:
<img width="749" height="257" alt="image" src="https://github.com/user-attachments/assets/b3e11285-564f-407e-9657-9c0401139202" />


## Pre-merge Checklist
- [x] Screenshots of these widgets in designer are included above (`try_in_designer.sh`)
- [x] Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)
- [x] Description and screenshot and of these widgets working are added to the ECS Widget Catalog https://confluence.slac.stanford.edu/spaces/PCDS/pages/716925985/ECS+UI+UX+pcdswidgets+Widget+Catalog
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] New/changed widgets are part of the test suite (semi-automatic)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
