### PR TITLE
WIP: add console entrypoint for showing widgets as screens

### DIFF
--- a/pcdswidgets/show_screen.py
+++ b/pcdswidgets/show_screen.py
@@ -1,0 +1,71 @@
+"""
+CLI entrypoint for opening expert screens and other widgets as standalone windows.
+"""
+
+import argparse
+import inspect
+from collections import defaultdict
+
+from qtpy.QtGui import QCursor
+from qtpy.QtWidgets import QApplication, QWidget
+
+from .builder.entrypoint_finder import iter_all_widgets
+
+try:
+    from qtpy.QtCore import pyqtProperty
+except ImportError:
+    from qtpy.QtCore import Property as pyqtProperty  # type: ignore
+
+
+def main():
+    widget_types: dict[str, type[QWidget]] = {}
+    widget_names_by_category: dict[str, list[str]] = defaultdict(list)
+    for name, WidgetType in iter_all_widgets():
+        module = inspect.getmodule(WidgetType)
+        if module is None:
+            continue
+        category = ".".join(module.__name__.split(".")[1:][:2])
+        widget_types[name] = WidgetType
+        widget_names_by_category[category].append(name)
+
+    widget_type_help = ""
+
+    for category in sorted(widget_names_by_category):
+        widget_type_help += f"{category}:\n"
+        widget_type_help += " ".join(sorted(widget_names_by_category[category])) + "\n\n"
+
+    parser = argparse.ArgumentParser(
+        prog="pcdswidgets-show",
+        description="Show a single widget as a screen. See help text for individual widget types for options.",
+        epilog=widget_type_help,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(title="widget types", required=True, metavar="WidgetType")
+
+    for name, WidgetType in widget_types.items():
+        sp = subparsers.add_parser(name=name)
+        sp.set_defaults(widget=name)
+        for name, val in inspect.getmembers(WidgetType):
+            if name == "rules":
+                # pydm rules don't make sense here, skip to avoid confusion
+                continue
+            if isinstance(val, pyqtProperty):
+                doc = inspect.getdoc(val.fget)
+                if isinstance(doc, str):
+                    doc = doc.split("\n")[0]
+                sp.add_argument(f"--{name}", default=argparse.SUPPRESS, help=doc)
+
+    app = QApplication([])
+    args = parser.parse_args()
+    widget = widget_types[args.widget]()
+    for prop, value in vars(args).items():
+        if prop != "widget":
+            # Note: assuming that everything is settable as a string- may not be true!
+            widget.setProperty(prop, value)
+    widget.move(QCursor.pos())
+    widget.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ include_package_data = true
 [project.license]
 file = "LICENSE.md"
 
+[project.scripts]
+pcdswidgets-show = "pcdswidgets.show_screen:main"
+
 [tool.setuptools_scm]
 write_to = "pcdswidgets/_version.py"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a console entrypoint, `pcdswidgets-show`, that can be used to show any widget from `pcdswidgets` as a standalone screen. This allows us to implement expert screens as widgets within `pcdswidgets` for easy maintenance and access from smaller widgets, while also allowing us to launch them by themselves from the command line. This also allows us to open any widget quickly as a debug tool.

Each widget is gathered at runtime via the same mechanisms we use to generate the pyproject.toml configuration, and each of those widgets is dynamically inspected to identify any designer properties that we added in the python layer, exposing those as cli arguments automatically.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://jira.slac.stanford.edu/browse/ECS-10969

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only.
Here are some commands that give fun output:
```
pixi run pcdswidgets-show --help
pixi run pcdswidgets-show MotorStateMoverExpanded --help
pixi run pcdswidgets-show MotorStateMoverExpanded --device "IM3L0:PPM:MMS"
```

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only- this is a work in progress.

## Screenshots
<!--  Include a screenshot of the related widgets in designer and in pydm -->

## Pre-merge Checklist
- [ ] ~Screenshots of these widgets in designer are included above (`try_in_designer.sh`)~
- [ ] Screenshots of these widgets working in PyDM are included above (`try_in_pydm.sh`)
- [ ] ~Description and screenshot and of these widgets working are added to the ECS Widget Catalog https://confluence.slac.stanford.edu/spaces/PCDS/pages/716925985/ECS+UI+UX+pcdswidgets+Widget+Catalog~
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] New/changed widgets are part of the test suite (semi-automatic)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
